### PR TITLE
Retryable RestOperations & Metaserver scheduled cache update

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -39,6 +39,11 @@
 			<artifactId>spring-boot</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-webmvc</artifactId>
 		</dependency>

--- a/core/src/main/java/com/ctrip/xpipe/api/retry/RetryTemplate.java
+++ b/core/src/main/java/com/ctrip/xpipe/api/retry/RetryTemplate.java
@@ -9,6 +9,6 @@ import com.ctrip.xpipe.api.command.Command;
  */
 public interface RetryTemplate<V> {
 	
-	V execute(Command<V> command) throws InterruptedException;
+	V execute(Command<V> command) throws Throwable;
 
 }

--- a/core/src/main/java/com/ctrip/xpipe/command/AbstractCommand.java
+++ b/core/src/main/java/com/ctrip/xpipe/command/AbstractCommand.java
@@ -68,7 +68,7 @@ public abstract class AbstractCommand<V> implements Command<V>{
 			public void run() {
 				try{
 					doExecute();
-				}catch(Exception e){
+				}catch(Throwable e){
 					if(!future().isDone()){
 						future().setFailure(e);
 					}
@@ -83,7 +83,7 @@ public abstract class AbstractCommand<V> implements Command<V>{
 		
 	}
 
-	protected abstract void doExecute() throws Exception;
+	protected abstract void doExecute() throws Throwable;
 
 	@Override
 	public CommandFuture<V> execute(final int time, TimeUnit timeUnit) {

--- a/core/src/main/java/com/ctrip/xpipe/concurrent/AbstractExceptionLogTask.java
+++ b/core/src/main/java/com/ctrip/xpipe/concurrent/AbstractExceptionLogTask.java
@@ -21,6 +21,6 @@ public abstract class AbstractExceptionLogTask implements Runnable{
 		}
 	}
 	
-	protected abstract void doRun() throws Exception;
+	protected abstract void doRun() throws Throwable;
 
 }

--- a/core/src/main/java/com/ctrip/xpipe/concurrent/OneThreadTaskExecutor.java
+++ b/core/src/main/java/com/ctrip/xpipe/concurrent/OneThreadTaskExecutor.java
@@ -50,7 +50,7 @@ public class OneThreadTaskExecutor implements Destroyable{
 
 		@Override
 		@SuppressWarnings({ "unchecked" })
-		protected void doRun() throws Exception {
+		protected void doRun() throws Throwable {
 			retryTemplate.execute(command);
 		}
 		

--- a/core/src/main/java/com/ctrip/xpipe/retry/RestOperationsRetryPolicy.java
+++ b/core/src/main/java/com/ctrip/xpipe/retry/RestOperationsRetryPolicy.java
@@ -1,0 +1,37 @@
+package com.ctrip.xpipe.retry;
+
+import org.springframework.web.client.ResourceAccessException;
+
+import com.ctrip.xpipe.api.retry.RetryPolicy;
+
+/**
+ * @author shyin
+ *
+ *         Sep 20, 2016
+ */
+public class RestOperationsRetryPolicy extends AbstractRetryPolicy implements RetryPolicy {
+
+	private int retryInterval;
+	
+	public RestOperationsRetryPolicy() {
+		this(10);
+	}
+
+	public RestOperationsRetryPolicy(int retryInterval) {
+		this.retryInterval = retryInterval;
+	}
+
+	@Override
+	public boolean retry(Throwable e) {
+		if(e.getCause() instanceof ResourceAccessException) {
+			return true;
+		}
+		return false;
+	}
+
+	@Override
+	protected int getSleepTime(int currentRetryTime) {
+		return (retryInterval <= 0) ? 0 : retryInterval;
+	}
+
+}

--- a/core/src/main/java/com/ctrip/xpipe/retry/RestOperationsRetryPolicyFactory.java
+++ b/core/src/main/java/com/ctrip/xpipe/retry/RestOperationsRetryPolicyFactory.java
@@ -1,0 +1,22 @@
+package com.ctrip.xpipe.retry;
+
+import com.ctrip.xpipe.api.retry.RetryPolicy;
+
+/**
+ * @author shyin
+ *
+ *         Sep 20, 2016
+ */
+public class RestOperationsRetryPolicyFactory implements RetryPolicyFactory {
+	private int retryInterval;
+
+	public RestOperationsRetryPolicyFactory(int retryInterval) {
+		this.retryInterval = retryInterval;
+	}
+
+	@Override
+	public RetryPolicy create() {
+		return new RestOperationsRetryPolicy(retryInterval);
+	}
+
+}

--- a/core/src/main/java/com/ctrip/xpipe/retry/RetryNTimes.java
+++ b/core/src/main/java/com/ctrip/xpipe/retry/RetryNTimes.java
@@ -39,7 +39,7 @@ public class RetryNTimes<V> extends AbstractRetryTemplate<V>{
 	}
 	
 	@Override
-	public V execute(Command<V> command) throws InterruptedException{
+	public V execute(Command<V> command) throws Throwable{
 		
 		for(int i=0;n== -1 || i<=n;i++){
 			

--- a/core/src/main/java/com/ctrip/xpipe/retry/RetryPolicyFactories.java
+++ b/core/src/main/java/com/ctrip/xpipe/retry/RetryPolicyFactories.java
@@ -1,0 +1,16 @@
+package com.ctrip.xpipe.retry;
+
+/**
+ * @author shyin
+ *
+ *         Sep 21, 2016
+ */
+public class RetryPolicyFactories {
+	public static RetryPolicyFactory newRestOperationsRetryPolicyFactory() {
+		return newRestOperationsRetryPolicyFactory(10);
+	}
+
+	public static RetryPolicyFactory newRestOperationsRetryPolicyFactory(int retryInterval) {
+		return new RestOperationsRetryPolicyFactory(retryInterval);
+	}
+}

--- a/core/src/main/java/com/ctrip/xpipe/retry/RetryPolicyFactory.java
+++ b/core/src/main/java/com/ctrip/xpipe/retry/RetryPolicyFactory.java
@@ -1,0 +1,12 @@
+package com.ctrip.xpipe.retry;
+
+import com.ctrip.xpipe.api.retry.RetryPolicy;
+
+/**
+ * @author shyin
+ *
+ * Sep 21, 2016
+ */
+public interface RetryPolicyFactory {
+	public RetryPolicy create();
+}

--- a/core/src/main/java/com/ctrip/xpipe/spring/RestTemplateFactory.java
+++ b/core/src/main/java/com/ctrip/xpipe/spring/RestTemplateFactory.java
@@ -1,39 +1,107 @@
 package com.ctrip.xpipe.spring;
 
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.config.SocketConfig;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.RestOperations;
 import org.springframework.web.client.RestTemplate;
+
+import com.ctrip.xpipe.api.retry.RetryPolicy;
+import com.ctrip.xpipe.command.AbstractCommand;
+import com.ctrip.xpipe.retry.RetryPolicyFactory;
+import com.ctrip.xpipe.retry.RetryNTimes;
+import com.ctrip.xpipe.retry.RetryPolicyFactories;
 
 /**
  * @author wenchao.meng
  *
- * Aug 5, 2016
+ *         Aug 5, 2016
  */
 public class RestTemplateFactory {
-	
-	public static RestTemplate createRestTemplate(){
-		
+
+	public static RestTemplate createRestTemplate() {
+
 		return new RestTemplate();
 	}
 
-	public static RestTemplate createCommonsHttpRestTemplate(){
-		return createCommonsHttpRestTemplate(10, 100, 5000, 5000);
+	public static RestOperations createCommonsHttpRestTemplate() {
+		return createCommonsHttpRestTemplate(10, 100, 5000, 5000, 10,
+				RetryPolicyFactories.newRestOperationsRetryPolicyFactory(10));
 	}
 
-	public static RestTemplate createCommonsHttpRestTemplate(int maxConnPerRoute, int maxConnTotal, int connectTimeout, int soTimeout){
-	
-		HttpClient httpClient = HttpClientBuilder.create()
-				.setMaxConnPerRoute(maxConnPerRoute)
+	public static RestOperations createCommonsHttpRestTemplate(int maxConnPerRoute, int maxConnTotal,
+			int connectTimeout, int soTimeout) {
+		return createCommonsHttpRestTemplate(maxConnPerRoute, maxConnTotal, connectTimeout, soTimeout, 10,
+				RetryPolicyFactories.newRestOperationsRetryPolicyFactory(10));
+	}
+
+	public static RestOperations createCommonsHttpRestTemplate(int maxConnPerRoute, int maxConnTotal,
+			int connectTimeout, int soTimeout, int retryTimes, RetryPolicyFactory retryPolicyFactory) {
+
+		HttpClient httpClient = HttpClientBuilder.create().setMaxConnPerRoute(maxConnPerRoute)
 				.setMaxConnTotal(maxConnTotal)
 				.setDefaultSocketConfig(SocketConfig.custom().setSoTimeout(soTimeout).build())
-				.setDefaultRequestConfig(RequestConfig.custom().setConnectTimeout(connectTimeout).build())
-				.build();
-		ClientHttpRequestFactory factory = new HttpComponentsClientHttpRequestFactory(httpClient); 
-		return new RestTemplate(factory);
+				.setDefaultRequestConfig(RequestConfig.custom().setConnectTimeout(connectTimeout).build()).build();
+		ClientHttpRequestFactory factory = new HttpComponentsClientHttpRequestFactory(httpClient);
+		RestTemplate restTemplate = new RestTemplate(factory);
+
+		return (RestOperations) Proxy.newProxyInstance(RestOperations.class.getClassLoader(),
+				new Class[] { RestOperations.class },
+				new RetryableRestOperationsHandler(restTemplate, retryTimes, retryPolicyFactory));
+	}
+
+	private static class RetryableRestOperationsHandler implements InvocationHandler {
+
+		private RestTemplate restTemplate;
+
+		private int retryTimes;
+
+		private RetryPolicyFactory retryPolicyFactory;
+
+		public RetryableRestOperationsHandler(RestTemplate restTemplate, int retryTimes,
+				RetryPolicyFactory retryPolicyFactory) {
+			this.restTemplate = restTemplate;
+			this.retryTimes = retryTimes;
+			this.retryPolicyFactory = retryPolicyFactory;
+		}
+
+		@Override
+		public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+			return retryableInvoke(restTemplate, method, args);
+		}
+
+		public Object retryableInvoke(final Object proxy, final Method method, final Object[] args) throws Throwable {
+			RetryPolicy retryPolicy = retryPolicyFactory.create();
+
+			return new RetryNTimes<Object>(retryTimes, retryPolicy).execute(new AbstractCommand<Object>() {
+
+				@Override
+				public String getName() {
+					return "RetryableRestInvoke";
+				}
+
+				@Override
+				protected void doExecute() throws Throwable {
+					try {
+						future().setSuccess(method.invoke(proxy, args));
+					} catch (Exception e) {
+						throw e.getCause();
+					}
+				}
+
+				@Override
+				protected void doReset() {
+					return;
+				}
+			});
+		}
+
 	}
 
 }

--- a/core/src/main/java/com/ctrip/xpipe/spring/RestTemplateFactory.java
+++ b/core/src/main/java/com/ctrip/xpipe/spring/RestTemplateFactory.java
@@ -3,6 +3,8 @@ package com.ctrip.xpipe.spring;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.util.concurrent.TimeUnit;
+
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.config.SocketConfig;
@@ -12,8 +14,10 @@ import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.web.client.RestOperations;
 import org.springframework.web.client.RestTemplate;
 
+import com.ctrip.xpipe.api.command.Command;
 import com.ctrip.xpipe.api.retry.RetryPolicy;
 import com.ctrip.xpipe.command.AbstractCommand;
+import com.ctrip.xpipe.exception.ExceptionUtils;
 import com.ctrip.xpipe.retry.RetryPolicyFactory;
 import com.ctrip.xpipe.retry.RetryNTimes;
 import com.ctrip.xpipe.retry.RetryPolicyFactories;
@@ -77,9 +81,36 @@ public class RestTemplateFactory {
 		}
 
 		public Object retryableInvoke(final Object proxy, final Method method, final Object[] args) throws Throwable {
-			RetryPolicy retryPolicy = retryPolicyFactory.create();
+			final RetryPolicy retryPolicy = retryPolicyFactory.create();
 
-			return new RetryNTimes<Object>(retryTimes, retryPolicy).execute(new AbstractCommand<Object>() {
+			return new RetryNTimes<Object>(retryTimes, retryPolicy) {
+				@Override
+				public Object execute(Command<Object> command) throws Throwable {
+					for (int i = 0; retryTimes == -1 || i <= retryTimes; i++) {
+
+						if (i >= 1) {
+							logger.info("[execute][retry]{}, {}", i, command);
+							retryPolicy.retryWaitMilli(true);
+						}
+
+						try {
+							return command.execute().get(retryPolicy.waitTimeoutMilli(), TimeUnit.MILLISECONDS);
+						} catch (Exception e) {
+							ExceptionUtils.logException(logger, e,
+									String.format("cmd:%s, message:%s", command, e.getMessage()));
+							if (i == retryTimes) {
+								throw e.getCause().getCause();// Get original exception
+							}
+							if (!retryPolicy.retry(e)) {
+								logger.info("[execute][no retry]", e);
+								break;
+							}
+						}
+						command.reset();
+					}
+					return null;
+				}
+			}.execute(new AbstractCommand<Object>() {
 
 				@Override
 				public String getName() {
@@ -88,11 +119,7 @@ public class RestTemplateFactory {
 
 				@Override
 				protected void doExecute() throws Throwable {
-					try {
-						future().setSuccess(method.invoke(proxy, args));
-					} catch (Exception e) {
-						throw e.getCause();
-					}
+					future().setSuccess(method.invoke(proxy, args));
 				}
 
 				@Override

--- a/core/src/main/java/com/ctrip/xpipe/utils/CatAppender4Log4j2.java
+++ b/core/src/main/java/com/ctrip/xpipe/utils/CatAppender4Log4j2.java
@@ -20,14 +20,11 @@ import com.dianping.cat.message.Trace;
 /**
  * @author shyin
  *
- * Aug 11, 2016
+ *         Aug 11, 2016
  */
-@Plugin(name="CatAppender4Log4j2", category="Core", elementType="appender", printObject=true)
-public final class CatAppender4Log4j2 extends AbstractAppender{
+@Plugin(name = "CatAppender4Log4j2", category = "Core", elementType = "appender", printObject = true)
+public final class CatAppender4Log4j2 extends AbstractAppender {
 
-	/**
-	 * 
-	 */
 	private static final long serialVersionUID = 1L;
 
 	/**
@@ -39,22 +36,19 @@ public final class CatAppender4Log4j2 extends AbstractAppender{
 		super(name, filter, layout);
 	}
 
-	/* (non-Javadoc)
-	 * @see org.apache.logging.log4j.core.Appender#append(org.apache.logging.log4j.core.LogEvent)
-	 */
 	@Override
 	public void append(LogEvent event) {
 		boolean isTraceMode = Cat.getManager().isTraceMode();
-		Level level = event.getLevel(); 
+		Level level = event.getLevel();
 
 		if (level.isMoreSpecificThan(Level.ERROR)) {
 			logError(event);
 		} else if (isTraceMode) {
 			logTrace(event);
 		}
-		
+
 	}
-	
+
 	private String buildExceptionStack(Throwable exception) {
 		if (exception != null) {
 			StringWriter writer = new StringWriter(2048);
@@ -68,13 +62,11 @@ public final class CatAppender4Log4j2 extends AbstractAppender{
 
 	private void logError(LogEvent event) {
 		Throwable info = event.getThrown();
-
 		if (info != null) {
 			Throwable exception = info;
 			Object message = event.getMessage();
-			System.out.println(message);
 			if (message != null) {
-				
+
 				Cat.logError(String.valueOf(message), exception);
 			} else {
 				Cat.logError(exception);
@@ -101,13 +93,12 @@ public final class CatAppender4Log4j2 extends AbstractAppender{
 		}
 		Cat.logTrace(type, name, Trace.SUCCESS, data);
 	}
-	
+
 	@PluginFactory
-	public static CatAppender4Log4j2 createAppender(
-			@PluginAttribute("name") String name,
+	public static CatAppender4Log4j2 createAppender(@PluginAttribute("name") String name,
 			@PluginElement("Layout") Layout<? extends Serializable> layout,
 			@PluginElement("Filter") final Filter filter) {
-		return new CatAppender4Log4j2(name,filter,layout);
+		return new CatAppender4Log4j2(name, filter, layout);
 	}
 
 }

--- a/core/src/test/java/com/ctrip/xpipe/retry/RestOperationsRetryPolicyTest.java
+++ b/core/src/test/java/com/ctrip/xpipe/retry/RestOperationsRetryPolicyTest.java
@@ -1,0 +1,46 @@
+package com.ctrip.xpipe.retry;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.web.client.ResourceAccessException;
+
+import com.ctrip.xpipe.AbstractTest;
+
+/**
+ * @author shyin
+ *
+ *         Sep 20, 2016
+ */
+public class RestOperationsRetryPolicyTest extends AbstractTest {
+	private RestOperationsRetryPolicy policy;
+
+	@Before
+	public void setUp() {
+		policy = new RestOperationsRetryPolicy();
+	}
+
+	@Test
+	public void testCreate() {
+		assertNotNull(policy);
+		assertEquals(0, policy.getRetryTimes());
+		assertEquals(3600000, policy.waitTimeoutMilli());
+		assertEquals(false, policy.timeoutCancel());
+	}
+
+	@Test
+	public void testRetryWait() throws InterruptedException {
+		assertEquals(10, policy.retryWaitMilli());
+		assertEquals(10, policy.getSleepTime(0));
+	}
+
+	@Test
+	public void testRetryJudgement() throws InterruptedException {
+		assertEquals(true, policy.retry(new Exception(new ResourceAccessException(null))));
+		assertEquals(false, policy.retry(new IOException()));
+	}
+
+}

--- a/core/src/test/java/com/ctrip/xpipe/retry/RetryNTimesTest.java
+++ b/core/src/test/java/com/ctrip/xpipe/retry/RetryNTimesTest.java
@@ -15,14 +15,14 @@ import com.ctrip.xpipe.command.AbstractCommand;
 public class RetryNTimesTest extends AbstractTest{
 	
 	@Test
-	public void testSuccess() throws InterruptedException{
+	public void testSuccess() throws Throwable{
 		
 		RetryNTimes<Object> retryNTimes = new RetryNTimes<Object>(100, new RetryDelay(100));
 		Assert.assertNotNull(retryNTimes.execute(new TestRetryCommand(new Object())));
 	}
 	
 	@Test
-	public void testFailRetry() throws InterruptedException{
+	public void testFailRetry() throws Throwable{
 
 		int retryTimes = 3;
 		RetryDelay retryDelay = new RetryDelay(100);
@@ -34,7 +34,7 @@ public class RetryNTimesTest extends AbstractTest{
 	}
 	
 	@Test
-	public void testFailNoRetry() throws InterruptedException{
+	public void testFailNoRetry() throws Throwable{
 
 		RetryPolicy retryPolicy = new RetryExceptionIsSuccess(100);
 		RetryNTimes<Object> retryNTimes = new RetryNTimes<Object>(3, retryPolicy);

--- a/core/src/test/java/com/ctrip/xpipe/retry/RetryableRestOperationsTest.java
+++ b/core/src/test/java/com/ctrip/xpipe/retry/RetryableRestOperationsTest.java
@@ -1,0 +1,48 @@
+package com.ctrip.xpipe.retry;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.mockito.Matchers.any;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.springframework.boot.SpringApplication;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.web.client.RestOperations;
+
+import com.ctrip.xpipe.api.retry.RetryPolicy;
+import com.ctrip.xpipe.simpleserver.SimpleTestSpringServer;
+import com.ctrip.xpipe.spring.RestTemplateFactory;
+
+/**
+ * @author shyin
+ *
+ *         Sep 20, 2016
+ */
+public class RetryableRestOperationsTest {
+	@Test
+	public void retryableRestOperationsSuccessTest() throws Exception {
+
+		SpringApplication application = new SpringApplication(SimpleTestSpringServer.class);
+		ConfigurableApplicationContext ctx = application.run("");
+		ctx.start();
+		RestOperations restOperations = RestTemplateFactory.createCommonsHttpRestTemplate();
+		assertEquals("for test", restOperations.getForObject("http://localhost:8080/test", String.class));
+		ctx.close();
+	}
+
+	@Test
+	public void retryableRestOperationsFailTest() {
+		int retryTimes = 10;
+		RetryPolicyFactory mockedRetryPolicyFactory = Mockito.mock(RetryPolicyFactory.class);
+		RetryPolicy mockedRetryPolicy = Mockito.mock(RetryPolicy.class);
+		when(mockedRetryPolicyFactory.create()).thenReturn(mockedRetryPolicy);
+		when(mockedRetryPolicy.retry(any(Throwable.class))).thenReturn(true);
+		RestOperations restOperations = RestTemplateFactory.createCommonsHttpRestTemplate(10, 100, 5000, 5000,
+				retryTimes, mockedRetryPolicyFactory);
+		restOperations.getForObject("http://localhost:8080/test", String.class);
+		verify(mockedRetryPolicy, times(retryTimes + 1)).retry(any(Throwable.class));
+	}
+}

--- a/core/src/test/java/com/ctrip/xpipe/retry/RetryableRestOperationsTest.java
+++ b/core/src/test/java/com/ctrip/xpipe/retry/RetryableRestOperationsTest.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 import org.springframework.boot.SpringApplication;
 import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestOperations;
 
 import com.ctrip.xpipe.api.retry.RetryPolicy;
@@ -33,7 +34,7 @@ public class RetryableRestOperationsTest {
 		ctx.close();
 	}
 
-	@Test
+	@Test(expected = ResourceAccessException.class)
 	public void retryableRestOperationsFailTest() {
 		int retryTimes = 10;
 		RetryPolicyFactory mockedRetryPolicyFactory = Mockito.mock(RetryPolicyFactory.class);

--- a/core/src/test/java/com/ctrip/xpipe/simple/CatAppender4Log4j2Test.java
+++ b/core/src/test/java/com/ctrip/xpipe/simple/CatAppender4Log4j2Test.java
@@ -1,0 +1,18 @@
+package com.ctrip.xpipe.simple;
+
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author shyin
+ *
+ * Sep 22, 2016
+ */
+public class CatAppender4Log4j2Test {
+	protected Logger logger = LoggerFactory.getLogger(getClass());
+	@Test
+	public void catAppender4Log4j2Test() {
+		logger.error("error!!!!!!", new Exception("Test Exception occured!!!"));
+	}
+}

--- a/core/src/test/java/com/ctrip/xpipe/simpleserver/SimpleTestSpringConfiguration.java
+++ b/core/src/test/java/com/ctrip/xpipe/simpleserver/SimpleTestSpringConfiguration.java
@@ -1,0 +1,17 @@
+package com.ctrip.xpipe.simpleserver;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * @author shyin
+ *
+ * Sep 20, 2016
+ */
+@RestController
+public class SimpleTestSpringConfiguration {
+	@RequestMapping("/test")
+	public String forTest() {
+		return "for test";
+	}
+}

--- a/core/src/test/java/com/ctrip/xpipe/simpleserver/SimpleTestSpringServer.java
+++ b/core/src/test/java/com/ctrip/xpipe/simpleserver/SimpleTestSpringServer.java
@@ -1,0 +1,15 @@
+package com.ctrip.xpipe.simpleserver;
+
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * @author shyin
+ *
+ * Sep 20, 2016
+ */
+@EnableAutoConfiguration
+@Import(com.ctrip.xpipe.simpleserver.SimpleTestSpringConfiguration.class)
+public class SimpleTestSpringServer{
+
+}

--- a/core/src/test/resources/log4j2.xml
+++ b/core/src/test/resources/log4j2.xml
@@ -18,7 +18,8 @@
                 <SizeBasedTriggeringPolicy size="100 MB"/>
             </Policies>
         </RollingFile>
-
+        
+		<CatAppender4Log4j2 name="CatAppender4Log4j2"></CatAppender4Log4j2>
     </appenders>
 
     <loggers>
@@ -41,6 +42,7 @@
         <root level="INFO">
             <appender-ref ref="Console"/>
             <appender-ref ref="RollingFileInfo"/>
+            <appender-ref ref="CatAppender4Log4j2"/>
         </root>
     </loggers>
 

--- a/redis/package/redis-console-package/src/main/config/log4j2.xml
+++ b/redis/package/redis-console-package/src/main/config/log4j2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<configuration status="info" shutdownHook="disable" monitorInterval="5" packages="com.ctrip.xpipe.utils">
+<configuration status="info" shutdownHook="disable" monitorInterval="5">
 
     <appenders>
         <console name="console" target="SYSTEM_OUT">

--- a/redis/package/redis-keeper-package/src/main/config/log4j2.xml
+++ b/redis/package/redis-keeper-package/src/main/config/log4j2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<configuration status="info" shutdownHook="disable" monitorInterval="5" packages="com.ctrip.xpipe.utils">
+<configuration status="info" shutdownHook="disable" monitorInterval="5">
 
     <appenders>
         <console name="console" target="SYSTEM_OUT">

--- a/redis/redis-console/src/main/config/log4j2.xml
+++ b/redis/redis-console/src/main/config/log4j2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<configuration status="trace" monitorInterval="5" packages="com.ctrip.xpipe.utils">
+<configuration status="info" monitorInterval="5">
 
     <appenders>
         <console name="Console" target="SYSTEM_OUT">

--- a/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/constant/XpipeConsoleConstant.java
+++ b/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/constant/XpipeConsoleConstant.java
@@ -10,7 +10,7 @@ public class XpipeConsoleConstant {
 	
 	public static int MAX_NAME_SIZE = 128;
 	
-	public static String DEFAULT_ADDRESS = "0.0.0.0:0000";
+	public static String DEFAULT_ADDRESS = "http://0.0.0.0:0000";
 	
 	public static String ROLE_REDIS = "redis";
 	public static String ROLE_KEEPER = "keeper";

--- a/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/service/notifier/DefaultClusterMetaModifiedNotifier.java
+++ b/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/service/notifier/DefaultClusterMetaModifiedNotifier.java
@@ -14,61 +14,49 @@ import com.ctrip.xpipe.redis.console.util.MetaServerConsoleServiceManagerWrapper
 /**
  * @author shyin
  *
- * Sep 6, 2016
+ *         Sep 6, 2016
  */
 @Component
-public class DefaultClusterMetaModifiedNotifier implements ClusterMetaModifiedNotifier{
+public class DefaultClusterMetaModifiedNotifier implements ClusterMetaModifiedNotifier {
 	Logger logger = LoggerFactory.getLogger(getClass());
 
 	@Autowired
 	private ClusterMetaService clusterMetaService;
-    @Autowired
-    private MetaServerConsoleServiceManagerWrapper metaServerConsoleServiceManagerWrapper;
-    
-    @Override
-    public void notifyClusterUpdate(final String dcName, final String clusterName) {
-    	try {
-    		logger.info("[notifyClusterUpdate][construct]{},{}",dcName,clusterName);
-    		metaServerConsoleServiceManagerWrapper.get(dcName).clusterModified(clusterName, clusterMetaService.getClusterMeta(dcName, clusterName));
-    		logger.info("[notifyClusterUpdate][success]{},{}",dcName,clusterName);
-    	} catch (Exception e) {
-    		logger.error("[notifyClusterUpdate][failed]{},{}",dcName,clusterName);
-    		logger.error("[notifyClusterUpdate][failed][rootCause]{}",e);
-    	}
-    	
-    }
-    
-    @Override
-    public void notifyClusterDelete(final String clusterName, List<DcTbl> dcs) {
-    	if(null != dcs) {
-    		for(DcTbl dc : dcs) {
-    			try {
-    				logger.info("[notifyClusterDelete][construct]{},{}",clusterName,dc.getDcName());
-    				metaServerConsoleServiceManagerWrapper.get(dc.getDcName()).clusterDeleted(clusterName);
-    				logger.info("[notifyClusterDelete][success]{},{}",clusterName,dc.getDcName());
-    			} catch (Exception e) {
-    				logger.error("[notifyClusterDelete][failed]{},{}",dc.getDcName(),clusterName);
-    				logger.error("[notifyClusterDelete][failed][rootCause]{}",e);
-				}
-    			
-    		}
-    	}
-    }
+	@Autowired
+	private MetaServerConsoleServiceManagerWrapper metaServerConsoleServiceManagerWrapper;
+
+	@Override
+	public void notifyClusterUpdate(final String dcName, final String clusterName) {
+		logger.info("[notifyClusterUpdate][construct]{},{}", dcName, clusterName);
+		metaServerConsoleServiceManagerWrapper.get(dcName).clusterModified(clusterName,
+				clusterMetaService.getClusterMeta(dcName, clusterName));
+		logger.info("[notifyClusterUpdate][finish]{},{}", dcName, clusterName);
+
+	}
+
+	@Override
+	public void notifyClusterDelete(final String clusterName, List<DcTbl> dcs) {
+		if (null != dcs) {
+			for (DcTbl dc : dcs) {
+				logger.info("[notifyClusterDelete][construct]{},{}", clusterName, dc.getDcName());
+				metaServerConsoleServiceManagerWrapper.get(dc.getDcName()).clusterDeleted(clusterName);
+				logger.info("[notifyClusterDelete][finish]{},{}", clusterName, dc.getDcName());
+			}
+		}
+	}
 
 	@Override
 	public void notifyUpstreamChanged(String clusterName, String shardName, String ip, int port, List<DcTbl> dcs) {
-		if(null != dcs) {
-			for(DcTbl dc : dcs) {
-				try {
-    				logger.info("[notifyUpstreamChanged][construct]{},{},{},{},{}",clusterName, shardName, ip, port, dc.getDcName());
-    				metaServerConsoleServiceManagerWrapper.get(dc.getDcName()).upstreamChange(clusterName, shardName, ip, port);
-    				logger.info("[notifyUpstreamChanged][success]{},{},{},{},{}",clusterName, shardName, ip, port, dc.getDcName());
-    			} catch (Exception e) {
-    				logger.error("[notifyUpstreamChanged][failed]{},{},{},{},{}",clusterName, shardName, ip, port, dc.getDcName());
-    				logger.error("[notifyUpstreamChanged][failed][rootCause]{}",e);
-				}
+		if (null != dcs) {
+			for (DcTbl dc : dcs) {
+				logger.info("[notifyUpstreamChanged][construct]{},{},{},{},{}", clusterName, shardName, ip, port,
+						dc.getDcName());
+				metaServerConsoleServiceManagerWrapper.get(dc.getDcName()).upstreamChange(clusterName, shardName, ip,
+						port);
+				logger.info("[notifyUpstreamChanged][finish]{},{},{},{},{}", clusterName, shardName, ip, port,
+						dc.getDcName());
 			}
 		}
-		
+
 	}
 }

--- a/redis/redis-console/src/main/resources/log4j2.xml
+++ b/redis/redis-console/src/main/resources/log4j2.xml
@@ -1,22 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<configuration status="info" shutdownHook="disable" monitorInterval="5">
+<configuration status="info" monitorInterval="5">
 
     <appenders>
-        <console name="console" target="SYSTEM_OUT">
+        <console name="Console" target="SYSTEM_OUT">
             <PatternLayout pattern="[%d{HH:mm:ss:SSS}][%p][%t][%C{1}]%m%n"/>
         </console>
 
-        <RollingFile name="rollingFileInfo" fileName="/opt/logs/100004375/metaserver.log"
-                     filePattern="/opt/logs/100004375/metaserver-%d{yyyy-MM-dd}-%i.log">
+        <RollingFile name="RollingFileInfo" fileName="target/applogs/xpipe-console.log"
+                     filePattern="target/applogs/xpipe-console-%d{yyyy-MM-dd}-%i.log">
             <PatternLayout pattern="[%d{HH:mm:ss:SSS}][%p][%t][%C{1}]%m%n"/>
             <Policies>
                 <TimeBasedTriggeringPolicy/>
                 <SizeBasedTriggeringPolicy size="500 MB"/>
             </Policies>
-        </RollingFile>
+        </RollingFile>	
 
-		<CatAppender4Log4j2 name="catAppender4Log4j2"/>
-
+		<CatAppender4Log4j2 name="catAppender4Log4j2"></CatAppender4Log4j2>
     </appenders>
 
     <loggers>
@@ -28,7 +27,7 @@
         <logger name="io.netty" level="INFO">
         </logger>
         <root level="INFO">
-            <appender-ref ref="rollingFileInfo"/>
+            <appender-ref ref="RollingFileInfo"/>
             <appender-ref ref="catAppender4Log4j2"/>
         </root>
     </loggers>

--- a/redis/redis-console/src/test/java/simpletest/CatAppenderTest.java
+++ b/redis/redis-console/src/test/java/simpletest/CatAppenderTest.java
@@ -1,17 +1,16 @@
 package simpletest;
 
 import org.junit.Test;
-
 import com.ctrip.xpipe.redis.console.AbstractConsoleTest;
 
 /**
  * @author shyin
  *
- * Aug 11, 2016
+ *         Aug 11, 2016
  */
 
-public class CatAppenderTest extends AbstractConsoleTest{
-	
+public class CatAppenderTest extends AbstractConsoleTest {
+
 	@Test
 	public void catAppenderTest() throws InterruptedException {
 		logger.error("CatAppender error message", new Exception("simple exception"));

--- a/redis/redis-console/src/test/resources/log4j2.xml
+++ b/redis/redis-console/src/test/resources/log4j2.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<configuration status="trace" monitorInterval="5" packages="com.ctrip.xpipe.utils">
+<configuration status="info">
 
     <appenders>
         <console name="Console" target="SYSTEM_OUT">
             <PatternLayout pattern="[%d{HH:mm:ss:SSS}][%p][%t][%C{1}]%m%n"/>
         </console>
 
-        <RollingFile name="RollingFileInfo" fileName="/opt/logs/100004374/xpipe-console.log"
-                     filePattern="/opt/logs/100004374/xpipe-console-%d{yyyy-MM-dd}-%i.log">
+        <RollingFile name="RollingFileInfo" fileName="target/applogs/xpipe-console.log"
+                     filePattern="target/applogs/xpipe-console-%d{yyyy-MM-dd}-%i.log">
             <PatternLayout pattern="[%d{HH:mm:ss:SSS}][%p][%t][%C{1}]%m%n"/>
             <Policies>
                 <TimeBasedTriggeringPolicy/>
@@ -15,7 +15,7 @@
             </Policies>
         </RollingFile>	
 
-		<CatAppender4Log4j2 name="catAppender4Log4j2"></CatAppender4Log4j2>
+		<CatAppender4Log4j2 name="CatAppender4Log4j2"></CatAppender4Log4j2>
     </appenders>
 
     <loggers>
@@ -27,8 +27,9 @@
         <logger name="io.netty" level="INFO">
         </logger>
         <root level="INFO">
+        	<appender-ref ref="Console"/>
             <appender-ref ref="RollingFileInfo"/>
-            <appender-ref ref="catAppender4Log4j2"/>
+            <appender-ref ref="CatAppender4Log4j2"/>
         </root>
     </loggers>
 

--- a/redis/redis-core/src/main/java/com/ctrip/xpipe/redis/core/meta/comparator/AbstractMetaComparator.java
+++ b/redis/redis-core/src/main/java/com/ctrip/xpipe/redis/core/meta/comparator/AbstractMetaComparator.java
@@ -38,17 +38,17 @@ public abstract class AbstractMetaComparator<T, C extends Enum<C>> implements Me
 	 * @param future
 	 * @return added, modified, delted
 	 */
-	protected Triple<Set<String>, Set<String>, Set<String>> getDiff(Set<String> current, Set<String> future) {
+	protected <Type> Triple<Set<Type>, Set<Type>, Set<Type>> getDiff(Set<Type> current, Set<Type> future) {
 		
-		Set<String> added = new HashSet<>(future);
-		Set<String> modified = new HashSet<>(future);
-		Set<String> deleted = new HashSet<>(current);
+		Set<Type> added = new HashSet<>(future);
+		Set<Type> modified = new HashSet<>(future);
+		Set<Type> deleted = new HashSet<>(current);
 		
 		added.removeAll(deleted);
 		modified.retainAll(deleted);
 		deleted.removeAll(future);
 		
-		return new Triple<Set<String>, Set<String>, Set<String>>(added, modified, deleted);
+		return new Triple<Set<Type>, Set<Type>, Set<Type>>(added, modified, deleted);
 	}
 
 	@Override

--- a/redis/redis-core/src/main/java/com/ctrip/xpipe/redis/core/metaserver/impl/AbstractMetaService.java
+++ b/redis/redis-core/src/main/java/com/ctrip/xpipe/redis/core/metaserver/impl/AbstractMetaService.java
@@ -5,8 +5,7 @@ import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.web.client.RestTemplate;
-
+import org.springframework.web.client.RestOperations;
 import com.ctrip.xpipe.redis.core.metaserver.MetaServerService;
 import com.ctrip.xpipe.spring.RestTemplateFactory;
 import com.google.common.base.Function;
@@ -20,7 +19,7 @@ public abstract class AbstractMetaService implements MetaServerService{
 	
 	protected Logger logger = LoggerFactory.getLogger(getClass());
 	
-	protected RestTemplate restTemplate = RestTemplateFactory.createCommonsHttpRestTemplate();
+	protected RestOperations restTemplate = RestTemplateFactory.createCommonsHttpRestTemplate();
 
 
 	protected <T> T pollMetaServer(Function<String, T> fun) {

--- a/redis/redis-integrated-test/src/test/java/com/ctrip/xpipe/redis/integratedtest/consoleapi/util/ApiTestExecitorPool.java
+++ b/redis/redis-integrated-test/src/test/java/com/ctrip/xpipe/redis/integratedtest/consoleapi/util/ApiTestExecitorPool.java
@@ -4,8 +4,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.web.client.RestTemplate;
-
+import org.springframework.web.client.RestOperations;
 import com.ctrip.xpipe.redis.core.transform.DefaultSaxParser;
 import com.ctrip.xpipe.spring.RestTemplateFactory;
 
@@ -22,7 +21,7 @@ public class ApiTestExecitorPool extends AbstractExecutorPool {
 	private int testNum;
 	private String url;
 	private String apiName;
-	private RestTemplate restTemplate = RestTemplateFactory
+	private RestOperations restTemplate = RestTemplateFactory
 			.createCommonsHttpRestTemplate(10, 100, 5000, 5000);
 
 	@SuppressWarnings("rawtypes")

--- a/redis/redis-meta/src/main/java/com/ctrip/xpipe/redis/meta/server/cluster/impl/AbstractRemoteClusterServer.java
+++ b/redis/redis-meta/src/main/java/com/ctrip/xpipe/redis/meta/server/cluster/impl/AbstractRemoteClusterServer.java
@@ -1,7 +1,6 @@
 package com.ctrip.xpipe.redis.meta.server.cluster.impl;
 
-import org.springframework.web.client.RestTemplate;
-
+import org.springframework.web.client.RestOperations;
 import com.ctrip.xpipe.api.command.CommandFuture;
 import com.ctrip.xpipe.command.AbstractCommand;
 import com.ctrip.xpipe.redis.meta.server.cluster.ClusterServerInfo;
@@ -21,7 +20,7 @@ public class AbstractRemoteClusterServer extends AbstractClusterServer implement
 	private int connectTimeout = Integer.parseInt(System.getProperty("remoteConnectTimeout", "5000"));
 	private int soTimeout = Integer.parseInt(System.getProperty("remoteSoTimeout", "5000"));
 
-	protected RestTemplate restTemplate;
+	protected RestOperations restTemplate;
 	
 	private int currentServerId;
 	

--- a/redis/redis-meta/src/main/java/com/ctrip/xpipe/redis/meta/server/keeper/container/DefaultKeeperContainerService.java
+++ b/redis/redis-meta/src/main/java/com/ctrip/xpipe/redis/meta/server/keeper/container/DefaultKeeperContainerService.java
@@ -9,8 +9,7 @@ import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.HttpStatusCodeException;
-import org.springframework.web.client.RestTemplate;
-
+import org.springframework.web.client.RestOperations;
 import java.util.List;
 
 /**
@@ -21,9 +20,9 @@ public class DefaultKeeperContainerService implements KeeperContainerService {
             ParameterizedTypeReference<List<KeeperInstanceMeta>>() {
             };
     private KeeperContainerMeta keeperContainerMeta;
-    private RestTemplate restTemplate;
+    private RestOperations restTemplate;
 
-    public DefaultKeeperContainerService(KeeperContainerMeta keeperContainerMeta, RestTemplate restTemplate) {
+    public DefaultKeeperContainerService(KeeperContainerMeta keeperContainerMeta, RestOperations restTemplate) {
         this.keeperContainerMeta = keeperContainerMeta;
         this.restTemplate = restTemplate;
     }

--- a/redis/redis-meta/src/main/java/com/ctrip/xpipe/redis/meta/server/keeper/container/DefaultKeeperContainerServiceFactory.java
+++ b/redis/redis-meta/src/main/java/com/ctrip/xpipe/redis/meta/server/keeper/container/DefaultKeeperContainerServiceFactory.java
@@ -7,8 +7,7 @@ import com.ctrip.xpipe.spring.RestTemplateFactory;
 
 import com.google.common.collect.Maps;
 import org.springframework.stereotype.Component;
-import org.springframework.web.client.RestTemplate;
-
+import org.springframework.web.client.RestOperations;
 import java.util.Map;
 
 /**
@@ -18,7 +17,7 @@ import java.util.Map;
 public class DefaultKeeperContainerServiceFactory implements KeeperContainerServiceFactory {
 
     private Map<KeeperContainerMeta, KeeperContainerService> services = Maps.newConcurrentMap();
-    private RestTemplate restTemplate = RestTemplateFactory.createCommonsHttpRestTemplate();
+    private RestOperations restTemplate = RestTemplateFactory.createCommonsHttpRestTemplate();
 
     @Override
     public KeeperContainerService getOrCreateKeeperContainerService(KeeperContainerMeta keeperContainerMeta) {

--- a/redis/redis-meta/src/main/java/com/ctrip/xpipe/redis/meta/server/meta/impl/DefaultDcMetaCache.java
+++ b/redis/redis-meta/src/main/java/com/ctrip/xpipe/redis/meta/server/meta/impl/DefaultDcMetaCache.java
@@ -127,6 +127,7 @@ public class DefaultDcMetaCache extends AbstractLifecycleObservable implements D
 				dcMetaComparator.compare();
 				
 				if(dcMetaComparator.totalChangedCount() == 0){
+					dcMetaManager.set(DefaultDcMetaManager.buildFromDcMeta(future));
 					return;
 				}
 				

--- a/redis/redis-meta/src/main/java/com/ctrip/xpipe/redis/meta/server/service/console/ConsoleServiceImpl.java
+++ b/redis/redis-meta/src/main/java/com/ctrip/xpipe/redis/meta/server/service/console/ConsoleServiceImpl.java
@@ -13,8 +13,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestTemplate;
-
+import org.springframework.web.client.RestOperations;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -34,7 +33,7 @@ public class ConsoleServiceImpl implements ConsoleService {
 	
 	private Logger logger = LoggerFactory.getLogger(getClass());
 
-	private RestTemplate restTemplate = RestTemplateFactory.createCommonsHttpRestTemplate();
+	private RestOperations restTemplate = RestTemplateFactory.createCommonsHttpRestTemplate();
 	private String host;
 
 	@PostConstruct

--- a/redis/redis-meta/src/test/java/com/ctrip/xpipe/redis/meta/server/cluster/ClusterServersMulticastTest.java
+++ b/redis/redis-meta/src/test/java/com/ctrip/xpipe/redis/meta/server/cluster/ClusterServersMulticastTest.java
@@ -3,8 +3,7 @@ package com.ctrip.xpipe.redis.meta.server.cluster;
 import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.web.client.HttpServerErrorException;
-import org.springframework.web.client.RestTemplate;
-
+import org.springframework.web.client.RestOperations;
 import com.ctrip.xpipe.redis.core.entity.ClusterMeta;
 import com.ctrip.xpipe.redis.core.metaserver.MetaServerConsoleService;
 import com.ctrip.xpipe.redis.meta.server.TestMetaServer;
@@ -19,7 +18,7 @@ import com.ctrip.xpipe.spring.RestTemplateFactory;
 public class ClusterServersMulticastTest extends AbstractMetaServerClusterTest{
 	
 	private int metaServerCount = 3;
-	private RestTemplate restTemplate = RestTemplateFactory.createCommonsHttpRestTemplate();
+	private RestOperations restTemplate = RestTemplateFactory.createCommonsHttpRestTemplate();
 	
 	@Test
 	public void simpleTest(){


### PR DESCRIPTION
For the commit [680f076] : I think that the function "execute" in RetryNTimes should reveal the original exceptions instead of returning a null which is ambiguous.Users might not be able to figure out whether the null means fail or it is just the return value.