### PR TITLE
Fix the bug that UT will fail due to h2 db

### DIFF
--- a/redis/redis-console/src/main/resources/META-INF/dal/jdbc/meta-dal.xml
+++ b/redis/redis-console/src/main/resources/META-INF/dal/jdbc/meta-dal.xml
@@ -508,6 +508,11 @@
 	</entity>
 
 	<entity name="redis-tbl" table="REDIS_TBL" alias="rt">
+		<!-- Add two constant below to fix bug, that when use h2 db in unit/integration test -->
+		<!-- RedisService.updateRedis() will fail, due to h2 db not recognize sequential insert with id of 0 -->
+		<member name="id" field="id" value-type="Long" length="20" nullable="true" key="true" auto-increment="true" />
+		<var name="key-id" value-type="Long" key-member="id" />
+
 		<var name="dc-name" value-type="String"/>
 		<var name="cluster-name" value-type="String"/>
 

--- a/redis/redis-console/src/main/resources/static/scripts/controllers/ClusterDcShardUpdateCtl.js
+++ b/redis/redis-console/src/main/resources/static/scripts/controllers/ClusterDcShardUpdateCtl.js
@@ -108,7 +108,7 @@ index_module.controller('ClusterDcShardUpdateCtl',
                              }
 
                              function createRedis() {
-                                 $scope.toCreateRedis.id = 0;
+//                                 $scope.toCreateRedis.id = 0;
                                  var shard = $scope.dcShards[$scope.currentDcName];
                                  shard.redises.push($scope.toCreateRedis);
                                  $scope.toCreateRedis = {};
@@ -170,7 +170,7 @@ index_module.controller('ClusterDcShardUpdateCtl',
                                     			 break;
                                     		 }
                                     	 }
-                                    	 $scope.toCreateFirstKeeper.id = 0;
+//                                    	 $scope.toCreateFirstKeeper.id = 0;
                                          shard.keepers.push($scope.toCreateFirstKeeper);
                                      }
 
@@ -186,7 +186,7 @@ index_module.controller('ClusterDcShardUpdateCtl',
                                     			 break;
                                     		 }
                                     	 }
-                                    	 otherKeeper.id = 0;
+//                                    	 otherKeeper.id = 0;
                                          shard.keepers.push(otherKeeper);
                                      }
                                  });


### PR DESCRIPTION
在Test部分进行Integration Test的时候，不能批量添加Redis和Keeper
Root Cause：
1. 前端代码在添加时，加入了id的赋值
2. h2 Database无法在bulk insert时候，识别连续的插入中id为0