### PR TITLE
Feature/add keeper container filter for bu backend

### DIFF
--- a/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/constant/XPipeConsoleConstant.java
+++ b/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/constant/XPipeConsoleConstant.java
@@ -22,6 +22,8 @@ public final class XPipeConsoleConstant {
 	public static String ROLE_KEEPER = "keeper";
 
 	public static final String DEFAULT_XPIPE_USER = "xpipe";
+
+	public static long DEFAULT_ORG_ID = 0L;
 	
 	private XPipeConsoleConstant(){
 		

--- a/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/controller/api/data/KeeperUpdateController.java
+++ b/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/controller/api/data/KeeperUpdateController.java
@@ -23,83 +23,87 @@ import java.util.List;
 @RequestMapping(AbstractConsoleController.API_PREFIX)
 public class KeeperUpdateController extends AbstractConsoleController {
 
-    @Autowired
-    private RedisService redisService;
+  @Autowired
+  private RedisService redisService;
 
-    @Autowired
-    private KeeperAdvancedService keeperAdvancedService;
+  @Autowired
+  private KeeperAdvancedService keeperAdvancedService;
 
-    @RequestMapping(value = "/keepers/{dcId}/{clusterId}/{shardId}", method = RequestMethod.GET)
-    public List<String> getKeepers(@PathVariable String dcId, @PathVariable String clusterId, @PathVariable String shardId) {
+  @RequestMapping(value = "/keepers/{dcId}/{clusterId}/{shardId}", method = RequestMethod.GET)
+  public List<String> getKeepers(@PathVariable String dcId, @PathVariable String clusterId,
+      @PathVariable String shardId) {
 
-        logger.info("[getRedises]{},{},{}", dcId, clusterId, shardId);
-        dcId = outerDcToInnerDc(dcId);
+    logger.info("[getRedises]{},{},{}", dcId, clusterId, shardId);
+    dcId = outerDcToInnerDc(dcId);
 
-        List<String> result = new LinkedList<>();
-        List<RedisTbl> keeperTbls = null;
-        try {
-            keeperTbls = redisService.findKeepersByDcClusterShard(dcId, clusterId, shardId);
-            result = formatToIpPort(keeperTbls);
-        } catch (ResourceNotFoundException e) {
-            logger.error("[getKeepers]", e);
-        }
-        return result;
+    List<String> result = new LinkedList<>();
+    List<RedisTbl> keeperTbls = null;
+    try {
+      keeperTbls = redisService.findKeepersByDcClusterShard(dcId, clusterId, shardId);
+      result = formatToIpPort(keeperTbls);
+    } catch (ResourceNotFoundException e) {
+      logger.error("[getKeepers]", e);
+    }
+    return result;
+  }
+
+  private List<String> formatToIpPort(List<RedisTbl> keeperTbls) {
+
+    List<String> result = new LinkedList<>();
+    keeperTbls.forEach(redisTbl -> result.add(String.format("%s:%d", redisTbl.getRedisIp(), redisTbl.getRedisPort())));
+    return result;
+  }
+
+  @RequestMapping(value = "/keepers/{dcId}/{clusterId}/{shardId}", method = RequestMethod.POST)
+  public RetMessage addKeepers(@PathVariable String dcId, @PathVariable String clusterId,
+      @PathVariable String shardId) {
+
+    logger.info("[addKeepers]{},{},{}, {}", dcId, clusterId, shardId);
+    dcId = outerDcToInnerDc(dcId);
+
+    try {
+      List<RedisTbl> keepers = redisService.findKeepersByDcClusterShard(dcId, clusterId, shardId);
+      if (keepers.size() > 0) {
+        return RetMessage.createSuccessMessage("alread has keepers:" + formatToIpPort(keepers));
+      }
+    } catch (ResourceNotFoundException e) {
+      logger.info("[addKeepers][not found]{}, {}, {}", dcId, clusterId, shardId);
+      return RetMessage.createFailMessage(e.getMessage());
     }
 
-    private List<String> formatToIpPort(List<RedisTbl> keeperTbls) {
-
-        List<String> result = new LinkedList<>();
-        keeperTbls.forEach(redisTbl -> result.add(String.format("%s:%d", redisTbl.getRedisIp(), redisTbl.getRedisPort())));
-        return result;
+    try {
+      List<KeeperBasicInfo> bestKeepers =
+          keeperAdvancedService.findBestKeepers(dcId, RedisProtocol.REDIS_PORT_DEFAULT, (ip, port) -> true, clusterId);
+      logger.info("[addKeepers]{},{},{},{}, {}", dcId, clusterId, shardId, bestKeepers);
+      redisService.insertKeepers(dcId, clusterId, shardId, bestKeepers);
+      return RetMessage.createSuccessMessage("insert success:" + bestKeepers);
+    } catch (Exception e) {
+      logger.error("[addKeepers]" + dcId + "," + clusterId + "," + shardId, e);
+      return RetMessage.createFailMessage("insert fail:" + e.getMessage());
     }
+  }
 
-    @RequestMapping(value = "/keepers/{dcId}/{clusterId}/{shardId}", method = RequestMethod.POST)
-    public RetMessage addKeepers(@PathVariable String dcId, @PathVariable String clusterId, @PathVariable String shardId) {
+  @RequestMapping(value = "/keepers/{dcId}/{clusterId}/{shardId}", method = RequestMethod.DELETE)
+  public RetMessage deleteKeepers(@PathVariable String dcId, @PathVariable String clusterId,
+      @PathVariable String shardId) {
 
-        logger.info("[addKeepers]{},{},{}, {}", dcId, clusterId, shardId);
-        dcId = outerDcToInnerDc(dcId);
+    logger.info("[deleteKeepers]{},{},{}, {}", dcId, clusterId, shardId);
 
-        try {
-            List<RedisTbl> keepers = redisService.findKeepersByDcClusterShard(dcId, clusterId, shardId);
-            if(keepers.size() > 0){
-                return RetMessage.createSuccessMessage("alread has keepers:" + formatToIpPort(keepers));
-            }
-        } catch (ResourceNotFoundException e) {
-            logger.info("[addKeepers][not found]{}, {}, {}", dcId, clusterId, shardId);
-            return RetMessage.createFailMessage(e.getMessage());
-        }
+    dcId = outerDcToInnerDc(dcId);
 
-        try {
-            List<KeeperBasicInfo> bestKeepers = keeperAdvancedService.findBestKeepers(dcId, RedisProtocol.REDIS_PORT_DEFAULT, (ip, port) -> true);
-            logger.info("[addKeepers]{},{},{},{}, {}", dcId, clusterId, shardId, bestKeepers);
-            redisService.insertKeepers(dcId, clusterId, shardId, bestKeepers);
-            return RetMessage.createSuccessMessage("insert success:" + bestKeepers);
-        }catch (Exception e){
-            logger.error("[addKeepers]" + dcId + "," + clusterId + "," + shardId, e);
-            return RetMessage.createFailMessage("insert fail:" + e.getMessage());
-        }
+    try {
+      List<RedisTbl> redisTbls = redisService.deleteKeepers(dcId, clusterId, shardId);
+
+      String message = null;
+      if (redisTbls.size() > 0) {
+        message = String.format("deleted:%s", formatToIpPort(redisTbls).toString());
+      } else {
+        message = "success, but already no keepers";
+      }
+      return RetMessage.createSuccessMessage(message);
+    } catch (Exception e) {
+      logger.error("[deleteKeepers]", e);
+      return RetMessage.createFailMessage(e.getMessage());
     }
-
-    @RequestMapping(value = "/keepers/{dcId}/{clusterId}/{shardId}", method = RequestMethod.DELETE)
-    public RetMessage deleteKeepers(@PathVariable String dcId, @PathVariable String clusterId, @PathVariable String shardId) {
-
-        logger.info("[deleteKeepers]{},{},{}, {}", dcId, clusterId, shardId);
-
-        dcId = outerDcToInnerDc(dcId);
-
-        try {
-            List<RedisTbl> redisTbls = redisService.deleteKeepers(dcId, clusterId, shardId);
-
-            String message = null;
-            if(redisTbls.size() > 0){
-                message = String.format("deleted:%s", formatToIpPort(redisTbls).toString());
-            }else{
-                message = "success, but already no keepers";
-            }
-            return RetMessage.createSuccessMessage(message);
-        } catch (Exception e) {
-            logger.error("[deleteKeepers]", e);
-            return RetMessage.createFailMessage(e.getMessage());
-        }
-    }
+  }
 }

--- a/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/controller/consoleportal/KeepercontainerDcController.java
+++ b/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/controller/consoleportal/KeepercontainerDcController.java
@@ -1,5 +1,6 @@
 package com.ctrip.xpipe.redis.console.controller.consoleportal;
 
+import com.ctrip.xpipe.redis.console.constant.XPipeConsoleConstant;
 import com.ctrip.xpipe.redis.console.controller.AbstractConsoleController;
 import com.ctrip.xpipe.redis.console.model.ClusterTbl;
 import com.ctrip.xpipe.redis.console.model.KeepercontainerTbl;
@@ -26,84 +27,88 @@ import java.util.List;
 @RequestMapping(AbstractConsoleController.CONSOLE_PREFIX)
 public class KeepercontainerDcController extends AbstractConsoleController {
 
-    @Autowired
-    private KeepercontainerService keepercontainerService;
+  @Autowired
+  private KeepercontainerService keepercontainerService;
 
-    @Autowired
-    private KeeperAdvancedService keeperAdvancedService;
+  @Autowired
+  private KeeperAdvancedService keeperAdvancedService;
 
-    @Autowired
-    private ClusterService clusterService;
+  @Autowired
+  private ClusterService clusterService;
 
-
-    @RequestMapping(value = "/dcs/{dcName}/cluster/{clusterName}/activekeepercontainers", method = RequestMethod.GET)
-    public List<KeepercontainerTbl> findKeeperContainersByCluster(@PathVariable String dcName,
-                                                                @PathVariable String clusterName) {
-        ClusterTbl clusterTbl = clusterService.find(clusterName);
-        long clusterOrgId = clusterTbl.getClusterOrgId();
-        return keepercontainerService.findKeeperCountByClusterOrg(dcName, clusterOrgId);
+  @RequestMapping(value = "/dcs/{dcName}/cluster/{clusterName}/activekeepercontainers", method = RequestMethod.GET)
+  public List<KeepercontainerTbl> findKeeperContainersByCluster(@PathVariable String dcName,
+      @PathVariable String clusterName) {
+    ClusterTbl clusterTbl = clusterService.find(clusterName);
+    long clusterOrgId = clusterTbl.getClusterOrgId();
+    List<KeepercontainerTbl> keepercontainerTbls =
+        keepercontainerService.findKeeperCountByClusterOrg(dcName, clusterOrgId);
+    if (keepercontainerTbls == null || keepercontainerTbls.isEmpty()) {
+      keepercontainerTbls =
+          keepercontainerService.findKeeperCountByClusterOrg(dcName, XPipeConsoleConstant.DEFAULT_ORG_ID);
     }
+    return keepercontainerTbls;
+  }
 
 
-    @RequestMapping(value = "/dcs/{dcName}/availablekeepers", method = RequestMethod.POST)
-    public List<RedisTbl> findAvailableKeepers(@PathVariable String dcName,
-                                               @RequestBody(required = false) ShardModel shardModel) {
+  @RequestMapping(value = "/dcs/{dcName}/availablekeepers", method = RequestMethod.POST)
+  public List<RedisTbl> findAvailableKeepers(@PathVariable String dcName,
+      @RequestBody(required = false) ShardModel shardModel) {
 
-        logger.debug("[findAvailableKeepers]{}, {}", dcName, shardModel);
+    logger.debug("[findAvailableKeepers]{}, {}", dcName, shardModel);
 
-        int beginPort = findBeginPort(shardModel);
+    int beginPort = findBeginPort(shardModel);
 
-        long clusterOrgId = getShardClusterOrgId(shardModel);
+    long clusterOrgId = getShardClusterOrgId(shardModel);
 
-        List<KeeperBasicInfo> bestKeepers = keeperAdvancedService.findBestKeepersByCluster(dcName, beginPort, (ip, port) -> {
+    List<KeeperBasicInfo> bestKeepers =
+        keeperAdvancedService.findBestKeepersByClusterOrg(dcName, beginPort, (ip, port) -> {
 
-            if (shardModel != null && existOnConsole(ip, port, shardModel.getKeepers())) {
-                return false;
-            }
-            return true;
+          if (shardModel != null && existOnConsole(ip, port, shardModel.getKeepers())) {
+            return false;
+          }
+          return true;
         }, clusterOrgId);
 
-        List<RedisTbl> result = new LinkedList<>();
+    List<RedisTbl> result = new LinkedList<>();
 
-        bestKeepers.forEach(keeperSelected -> result.add(
-                new RedisTbl().setKeepercontainerId(keeperSelected.getKeeperContainerId())
-                .setRedisIp(keeperSelected.getHost())
-                .setRedisPort(keeperSelected.getPort())
-        ));
-        return result;
+    bestKeepers
+        .forEach(keeperSelected -> result.add(new RedisTbl().setKeepercontainerId(keeperSelected.getKeeperContainerId())
+            .setRedisIp(keeperSelected.getHost()).setRedisPort(keeperSelected.getPort())));
+    return result;
+  }
+
+  private boolean existOnConsole(String keepercontainerIp, int port, List<RedisTbl> keepers) {
+
+    for (RedisTbl redisTbl : keepers) {
+      if (redisTbl.getRedisIp().equalsIgnoreCase(keepercontainerIp) && redisTbl.getRedisPort() == port) {
+        return true;
+      }
     }
+    return false;
+  }
 
-    private boolean existOnConsole(String keepercontainerIp, int port, List<RedisTbl> keepers) {
+  private int findBeginPort(ShardModel shardModel) {
 
-        for (RedisTbl redisTbl : keepers) {
-            if (redisTbl.getRedisIp().equalsIgnoreCase(keepercontainerIp)
-                    && redisTbl.getRedisPort() == port) {
-                return true;
-            }
-        }
-        return false;
+    int port = RedisProtocol.REDIS_PORT_DEFAULT;
+    if (shardModel != null && shardModel.getRedises().size() > 0) {
+      port = shardModel.getRedises().get(0).getRedisPort();
     }
+    return port;
+  }
 
-    private int findBeginPort(ShardModel shardModel) {
+  private long getShardClusterOrgId(ShardModel shardModel) {
+    if (shardModel == null)
+      return 0L;
+    long clusterId = shardModel.getShardTbl().getClusterId();
+    return getClusterOrgId(clusterId);
+  }
 
-        int port = RedisProtocol.REDIS_PORT_DEFAULT;
-        if (shardModel != null && shardModel.getRedises().size() > 0) {
-            port = shardModel.getRedises().get(0).getRedisPort();
-        }
-        return port;
+  private long getClusterOrgId(long clusterId) {
+    ClusterTbl clusterTbl = clusterService.find(clusterId);
+    if (clusterTbl == null) {
+      throw new IllegalStateException("Cluster could not be found by Id: " + clusterId);
     }
-
-    private long getShardClusterOrgId(ShardModel shardModel) {
-        if(shardModel == null)  return 0L;
-        long clusterId = shardModel.getShardTbl().getClusterId();
-        return getClusterOrgId(clusterId);
-    }
-
-    private long getClusterOrgId(long clusterId) {
-        ClusterTbl clusterTbl = clusterService.find(clusterId);
-        if(clusterTbl == null) {
-            throw new IllegalStateException("Cluster could not be found by Id: " + clusterId);
-        }
-        return clusterTbl.getClusterOrgId();
-    }
+    return clusterTbl.getClusterOrgId();
+  }
 }

--- a/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/controller/consoleportal/KeepercontainerDcController.java
+++ b/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/controller/consoleportal/KeepercontainerDcController.java
@@ -1,9 +1,11 @@
 package com.ctrip.xpipe.redis.console.controller.consoleportal;
 
 import com.ctrip.xpipe.redis.console.controller.AbstractConsoleController;
+import com.ctrip.xpipe.redis.console.model.ClusterTbl;
 import com.ctrip.xpipe.redis.console.model.KeepercontainerTbl;
 import com.ctrip.xpipe.redis.console.model.RedisTbl;
 import com.ctrip.xpipe.redis.console.model.ShardModel;
+import com.ctrip.xpipe.redis.console.service.ClusterService;
 import com.ctrip.xpipe.redis.console.service.KeeperAdvancedService;
 import com.ctrip.xpipe.redis.console.service.KeeperBasicInfo;
 import com.ctrip.xpipe.redis.console.service.KeepercontainerService;
@@ -30,10 +32,16 @@ public class KeepercontainerDcController extends AbstractConsoleController {
     @Autowired
     private KeeperAdvancedService keeperAdvancedService;
 
+    @Autowired
+    private ClusterService clusterService;
 
-    @RequestMapping(value = "/dcs/{dcName}/activekeepercontainers", method = RequestMethod.GET)
-    public List<KeepercontainerTbl> findKeeperContainer(@PathVariable String dcName) {
-        return keepercontainerService.findAllActiveByDcName(dcName);
+
+    @RequestMapping(value = "/dcs/{dcName}/cluster/{clusterName}/activekeepercontainers", method = RequestMethod.GET)
+    public List<KeepercontainerTbl> findKeeperContainersByCluster(@PathVariable String dcName,
+                                                                @PathVariable String clusterName) {
+        ClusterTbl clusterTbl = clusterService.find(clusterName);
+        long clusterOrgId = clusterTbl.getClusterOrgId();
+        return keepercontainerService.findKeeperCountByClusterOrg(dcName, clusterOrgId);
     }
 
 
@@ -45,13 +53,15 @@ public class KeepercontainerDcController extends AbstractConsoleController {
 
         int beginPort = findBeginPort(shardModel);
 
-        List<KeeperBasicInfo> bestKeepers = keeperAdvancedService.findBestKeepers(dcName, beginPort, (ip, port) -> {
+        long clusterOrgId = getShardClusterOrgId(shardModel);
+
+        List<KeeperBasicInfo> bestKeepers = keeperAdvancedService.findBestKeepersByCluster(dcName, beginPort, (ip, port) -> {
 
             if (shardModel != null && existOnConsole(ip, port, shardModel.getKeepers())) {
                 return false;
             }
             return true;
-        });
+        }, clusterOrgId);
 
         List<RedisTbl> result = new LinkedList<>();
 
@@ -81,5 +91,19 @@ public class KeepercontainerDcController extends AbstractConsoleController {
             port = shardModel.getRedises().get(0).getRedisPort();
         }
         return port;
+    }
+
+    private long getShardClusterOrgId(ShardModel shardModel) {
+        if(shardModel == null)  return 0L;
+        long clusterId = shardModel.getShardTbl().getClusterId();
+        return getClusterOrgId(clusterId);
+    }
+
+    private long getClusterOrgId(long clusterId) {
+        ClusterTbl clusterTbl = clusterService.find(clusterId);
+        if(clusterTbl == null) {
+            throw new IllegalStateException("Cluster could not be found by Id: " + clusterId);
+        }
+        return clusterTbl.getClusterOrgId();
     }
 }

--- a/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/service/KeeperAdvancedService.java
+++ b/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/service/KeeperAdvancedService.java
@@ -16,7 +16,7 @@ public interface KeeperAdvancedService {
 
   List<KeeperBasicInfo> findBestKeepers(String dcName);
 
-  List<KeeperBasicInfo> findBestKeepersByCluster(String dcName, int beginPort,
-      BiPredicate<String, Integer> keeperGood, long clusterId);
+  List<KeeperBasicInfo> findBestKeepersByClusterOrg(String dcName, int beginPort,
+      BiPredicate<String, Integer> keeperGood, long clusterOrgId);
 
 }

--- a/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/service/KeeperAdvancedService.java
+++ b/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/service/KeeperAdvancedService.java
@@ -12,11 +12,9 @@ import java.util.function.BiPredicate;
  */
 public interface KeeperAdvancedService {
 
-  List<KeeperBasicInfo> findBestKeepers(String dcName, int beginPort, BiPredicate<String, Integer> keeperGood);
+  List<KeeperBasicInfo> findBestKeepers(String dcName, int beginPort, BiPredicate<String, Integer> keeperGood,
+      String clusterName);
 
-  List<KeeperBasicInfo> findBestKeepers(String dcName);
-
-  List<KeeperBasicInfo> findBestKeepersByClusterOrg(String dcName, int beginPort,
-      BiPredicate<String, Integer> keeperGood, long clusterOrgId);
+  List<KeeperBasicInfo> findBestKeepers(String dcName, String clusterName);
 
 }

--- a/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/service/KeeperAdvancedService.java
+++ b/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/service/KeeperAdvancedService.java
@@ -1,5 +1,7 @@
 package com.ctrip.xpipe.redis.console.service;
 
+import com.ctrip.xpipe.redis.console.model.ShardModel;
+
 import java.util.List;
 import java.util.function.BiPredicate;
 
@@ -10,8 +12,11 @@ import java.util.function.BiPredicate;
  */
 public interface KeeperAdvancedService {
 
-    List<KeeperBasicInfo> findBestKeepers(String dcName, int beginPort, BiPredicate<String, Integer> keeperGood);
+  List<KeeperBasicInfo> findBestKeepers(String dcName, int beginPort, BiPredicate<String, Integer> keeperGood);
 
-    List<KeeperBasicInfo> findBestKeepers(String dcName);
+  List<KeeperBasicInfo> findBestKeepers(String dcName);
+
+  List<KeeperBasicInfo> findBestKeepersByCluster(String dcName, int beginPort,
+      BiPredicate<String, Integer> keeperGood, long clusterId);
 
 }

--- a/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/service/KeepercontainerService.java
+++ b/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/service/KeepercontainerService.java
@@ -10,5 +10,5 @@ public interface KeepercontainerService {
 	List<KeepercontainerTbl> findAllByDcName(String dcName);
 	List<KeepercontainerTbl> findAllActiveByDcName(String dcName);
 	List<KeepercontainerTbl> findKeeperCount(String dcName);
-	List<KeepercontainerTbl> findKeeperCountByClusterOrg(String dcName, long orgId);
+	List<KeepercontainerTbl> findBestKeeperContainersByDcCluster(String dcName, String clusterName);
 }

--- a/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/service/KeepercontainerService.java
+++ b/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/service/KeepercontainerService.java
@@ -10,5 +10,5 @@ public interface KeepercontainerService {
 	List<KeepercontainerTbl> findAllByDcName(String dcName);
 	List<KeepercontainerTbl> findAllActiveByDcName(String dcName);
 	List<KeepercontainerTbl> findKeeperCount(String dcName);
-
+	List<KeepercontainerTbl> findKeeperCountByClusterOrg(String dcName, long orgId);
 }

--- a/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/service/impl/DefaultKeeperAdvancedService.java
+++ b/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/service/impl/DefaultKeeperAdvancedService.java
@@ -34,58 +34,31 @@ public class DefaultKeeperAdvancedService extends AbstractConsoleService<RedisTb
   private ClusterService clusterService;
 
   @Override
-  public List<KeeperBasicInfo> findBestKeepers(String dcName) {
-    return findBestKeepers(dcName, RedisProtocol.REDIS_PORT_DEFAULT, (host, port) -> true);
+  public List<KeeperBasicInfo> findBestKeepers(String dcName, String clusterName) {
+    return findBestKeepers(dcName, RedisProtocol.REDIS_PORT_DEFAULT, (host, port) -> true, clusterName);
   }
 
   @Override
-  public List<KeeperBasicInfo> findBestKeepers(String dcName, int beginPort, BiPredicate keeperGood) {
-    return findBestKeepers(dcName, beginPort, keeperGood, 2);
+  public List<KeeperBasicInfo> findBestKeepers(String dcName, int beginPort, BiPredicate keeperGood,
+      String clusterName) {
+    return findBestKeepers(dcName, beginPort, keeperGood, clusterName, 2);
   }
 
   public List<KeeperBasicInfo> findBestKeepers(String dcName, int beginPort, BiPredicate<String, Integer> keeperGood,
-      int returnCount) {
-
-    List<KeepercontainerTbl> keeperCount = keepercontainerService.findKeeperCount(dcName);
-    if (keeperCount.size() < returnCount) {
-      throw new IllegalStateException("all keepers size:" + keeperCount + ", but we need:" + returnCount);
-    }
+      String clusterName, int returnCount) {
 
     List<KeeperBasicInfo> result = new LinkedList<>();
 
-    // find available port
-    fillInResult(keeperCount, result, beginPort, keeperGood, returnCount);
-    return result;
-
-  }
-
-  @Override
-  public List<KeeperBasicInfo> findBestKeepersByClusterOrg(String dcName, int beginPort,
-      BiPredicate<String, Integer> keeperGood, long clusterOrgId) {
-
-    return findBestKeepersByCluster(dcName, beginPort, keeperGood, clusterOrgId, 2);
-  }
-
-  private List<KeeperBasicInfo> findBestKeepersByCluster(String dcName, int beginPort,
-      BiPredicate<String, Integer> keeperGood, long clusterOrgId, int returnCount) {
-
-    List<KeeperBasicInfo> result = new LinkedList<>();
-    /*
-     * 1. BU has its own keepercontainer(kc), then find all and see if it satisfied the requirement 2. Cluster don't
-     * have a BU, find default one 3. BU don't have its own kc, find in the normal kc pool(org id is 0L)
-     */
     List<KeepercontainerTbl> keepercontainerTbls =
-        keepercontainerService.findKeeperCountByClusterOrg(dcName, clusterOrgId);
-    if (keepercontainerTbls == null || keepercontainerTbls.isEmpty()) {
-      keepercontainerTbls =
-          keepercontainerService.findKeeperCountByClusterOrg(dcName, XPipeConsoleConstant.DEFAULT_ORG_ID);
-    }
+        keepercontainerService.findBestKeeperContainersByDcCluster(dcName, clusterName);
     if (keepercontainerTbls.size() < returnCount) {
       throw new IllegalStateException(
           "Organization keepers size:" + keepercontainerTbls.size() + ", but we need:" + returnCount);
     }
+
     fillInResult(keepercontainerTbls, result, beginPort, keeperGood, returnCount);
     return result;
+
   }
 
   private void fillInResult(List<KeepercontainerTbl> keeperCount, List<KeeperBasicInfo> result, int beginPort,

--- a/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/service/impl/DefaultKeeperAdvancedService.java
+++ b/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/service/impl/DefaultKeeperAdvancedService.java
@@ -1,7 +1,9 @@
 package com.ctrip.xpipe.redis.console.service.impl;
 
+import com.ctrip.xpipe.redis.console.model.ClusterTbl;
 import com.ctrip.xpipe.redis.console.model.KeepercontainerTbl;
 import com.ctrip.xpipe.redis.console.model.RedisTblDao;
+import com.ctrip.xpipe.redis.console.model.ShardModel;
 import com.ctrip.xpipe.redis.console.service.*;
 import com.ctrip.xpipe.redis.core.protocal.RedisProtocol;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -9,7 +11,9 @@ import org.springframework.stereotype.Component;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.function.BiPredicate;
+import java.util.stream.Collectors;
 
 /**
  * @author wenchao.meng
@@ -19,86 +23,117 @@ import java.util.function.BiPredicate;
 @Component
 public class DefaultKeeperAdvancedService extends AbstractConsoleService<RedisTblDao> implements KeeperAdvancedService {
 
-    @Autowired
-    private KeepercontainerService keepercontainerService;
+  @Autowired
+  private KeepercontainerService keepercontainerService;
 
-    @Autowired
-    private RedisService redisService;
+  @Autowired
+  private RedisService redisService;
 
-    @Override
-    public List<KeeperBasicInfo> findBestKeepers(String dcName) {
-        return findBestKeepers(dcName, RedisProtocol.REDIS_PORT_DEFAULT, (host, port) -> true);
+  @Autowired
+  private ClusterService clusterService;
+
+  @Override
+  public List<KeeperBasicInfo> findBestKeepers(String dcName) {
+    return findBestKeepers(dcName, RedisProtocol.REDIS_PORT_DEFAULT, (host, port) -> true);
+  }
+
+  @Override
+  public List<KeeperBasicInfo> findBestKeepers(String dcName, int beginPort, BiPredicate keeperGood) {
+    return findBestKeepers(dcName, beginPort, keeperGood, 2);
+  }
+
+  public List<KeeperBasicInfo> findBestKeepers(String dcName, int beginPort, BiPredicate<String, Integer> keeperGood,
+      int returnCount) {
+
+    List<KeepercontainerTbl> keeperCount = keepercontainerService.findKeeperCount(dcName);
+    if (keeperCount.size() < returnCount) {
+      throw new IllegalStateException("all keepers size:" + keeperCount + ", but we need:" + returnCount);
     }
 
-    @Override
-    public List<KeeperBasicInfo> findBestKeepers(String dcName, int beginPort, BiPredicate keeperGood) {
-        return findBestKeepers(dcName, beginPort, keeperGood, 2);
+    List<KeeperBasicInfo> result = new LinkedList<>();
+
+    // find available port
+    fillInResult(keeperCount, result, beginPort, keeperGood, returnCount);
+    return result;
+
+  }
+
+  @Override
+  public List<KeeperBasicInfo> findBestKeepersByCluster(String dcName, int beginPort,
+      BiPredicate<String, Integer> keeperGood, long clusterOrgId) {
+
+    return findBestKeepersByCluster(dcName, beginPort, keeperGood, clusterOrgId, 2);
+  }
+
+  private List<KeeperBasicInfo> findBestKeepersByCluster(String dcName, int beginPort,
+      BiPredicate<String, Integer> keeperGood, long clusterOrgId, int returnCount) {
+
+    List<KeeperBasicInfo> result = new LinkedList<>();
+    List<KeepercontainerTbl> keeperCount = keepercontainerService.findKeeperCountByClusterOrg(dcName, clusterOrgId);
+    if (keeperCount.size() < returnCount) {
+      throw new IllegalStateException(
+          "Organization keepers size:" + keeperCount.size() + ", but we need:" + returnCount);
+    }
+    fillInResult(keeperCount, result, beginPort, keeperGood, returnCount);
+    return result;
+  }
+
+  private void fillInResult(List<KeepercontainerTbl> keeperCount, List<KeeperBasicInfo> result, int beginPort,
+      BiPredicate<String, Integer> keeperGood, int returnCount) {
+    // find available port
+    for (int i = 0; i < returnCount; i++) {
+
+      KeepercontainerTbl keepercontainerTbl = keeperCount.get(i);
+
+      KeeperBasicInfo keeperSelected = new KeeperBasicInfo();
+
+      keeperSelected.setKeeperContainerId(keepercontainerTbl.getKeepercontainerId());
+      keeperSelected.setHost(keepercontainerTbl.getKeepercontainerIp());
+
+      int port = findAvailablePort(keepercontainerTbl, beginPort, keeperGood, result);
+
+      keeperSelected.setPort(port);
+      result.add(keeperSelected);
+    }
+  }
+
+  private int findAvailablePort(KeepercontainerTbl keepercontainerTbl, int beginPort,
+      BiPredicate<String, Integer> keeperGood, List<KeeperBasicInfo> result) {
+
+    int port = beginPort;
+    String ip = keepercontainerTbl.getKeepercontainerIp();
+
+    for (;; port++) {
+
+      if (alreadySelected(ip, port, result)) {
+        continue;
+      }
+
+      if (!(keeperGood.test(ip, port))) {
+        continue;
+      }
+      if (existInDb(ip, port)) {
+        continue;
+      }
+
+      break;
     }
 
-    public List<KeeperBasicInfo> findBestKeepers(String dcName, int beginPort, BiPredicate<String, Integer> keeperGood, int returnCount) {
+    return port;
+  }
 
-        List<KeepercontainerTbl> keeperCount = keepercontainerService.findKeeperCount(dcName);
-        if (keeperCount.size() < returnCount) {
-            throw new IllegalStateException("all keepers size:" + keeperCount + ", but we need:" + returnCount);
-        }
+  private boolean alreadySelected(String ip, int port, List<KeeperBasicInfo> result) {
 
-        List<KeeperBasicInfo> result = new LinkedList<>();
-
-        //find available port
-        for (int i = 0; i < returnCount; i++) {
-
-            KeepercontainerTbl keepercontainerTbl = keeperCount.get(i);
-
-            KeeperBasicInfo keeperSelected = new KeeperBasicInfo();
-
-            keeperSelected.setKeeperContainerId(keepercontainerTbl.getKeepercontainerId());
-            keeperSelected.setHost(keepercontainerTbl.getKeepercontainerIp());
-
-            int port = findAvailablePort(keepercontainerTbl, beginPort, keeperGood, result);
-
-            keeperSelected.setPort(port);
-            result.add(keeperSelected);
-        }
-        return result;
-
+    for (KeeperBasicInfo keeperSelected : result) {
+      if (keeperSelected.getHost().equalsIgnoreCase(ip) && keeperSelected.getPort() == port) {
+        return true;
+      }
     }
+    return false;
+  }
 
-    private int findAvailablePort(KeepercontainerTbl keepercontainerTbl, int beginPort, BiPredicate<String, Integer> keeperGood, List<KeeperBasicInfo> result) {
-
-        int port = beginPort;
-        String ip = keepercontainerTbl.getKeepercontainerIp();
-
-        for (; ; port++) {
-
-            if (alreadySelected(ip, port, result)) {
-                continue;
-            }
-
-            if (!(keeperGood.test(ip, port))) {
-                continue;
-            }
-            if (existInDb(ip, port)) {
-                continue;
-            }
-
-            break;
-        }
-
-        return port;
-    }
-
-    private boolean alreadySelected(String ip, int port, List<KeeperBasicInfo> result) {
-
-        for (KeeperBasicInfo keeperSelected : result) {
-            if (keeperSelected.getHost().equalsIgnoreCase(ip) && keeperSelected.getPort() == port) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private boolean existInDb(String keepercontainerIp, int port) {
-        return redisService.findWithIpPort(keepercontainerIp, port) != null;
-    }
+  private boolean existInDb(String keepercontainerIp, int port) {
+    return redisService.findWithIpPort(keepercontainerIp, port) != null;
+  }
 
 }

--- a/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/service/impl/KeepercontainerServiceImpl.java
+++ b/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/service/impl/KeepercontainerServiceImpl.java
@@ -2,6 +2,10 @@ package com.ctrip.xpipe.redis.console.service.impl;
 
 import java.util.List;
 
+import com.ctrip.xpipe.redis.console.constant.XPipeConsoleConstant;
+import com.ctrip.xpipe.redis.console.model.ClusterTbl;
+import com.ctrip.xpipe.redis.console.service.ClusterService;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.unidal.dal.jdbc.DalException;
 
@@ -13,66 +17,88 @@ import com.ctrip.xpipe.redis.console.service.AbstractConsoleService;
 import com.ctrip.xpipe.redis.console.service.KeepercontainerService;
 
 @Service
-public class KeepercontainerServiceImpl extends AbstractConsoleService<KeepercontainerTblDao> implements KeepercontainerService {
+public class KeepercontainerServiceImpl extends AbstractConsoleService<KeepercontainerTblDao>
+    implements KeepercontainerService {
 
-	@Override
-	public KeepercontainerTbl find(final long id) {
-		return queryHandler.handleQuery(new DalQuery<KeepercontainerTbl>() {
-			@Override
-			public KeepercontainerTbl doQuery() throws DalException {
-				return dao.findByPK(id, KeepercontainerTblEntity.READSET_FULL);
-			}
-    	});
-	}
+  @Autowired
+  private ClusterService clusterService;
 
-	@Override
-	public List<KeepercontainerTbl> findAllByDcName(final String dcName) {
-		return queryHandler.handleQuery(new DalQuery<List<KeepercontainerTbl>>() {
-			@Override
-			public List<KeepercontainerTbl> doQuery() throws DalException {
-				return dao.findByDcName(dcName, KeepercontainerTblEntity.READSET_FULL);
-			}
-    	});
-	}
+  @Override
+  public KeepercontainerTbl find(final long id) {
+    return queryHandler.handleQuery(new DalQuery<KeepercontainerTbl>() {
+      @Override
+      public KeepercontainerTbl doQuery() throws DalException {
+        return dao.findByPK(id, KeepercontainerTblEntity.READSET_FULL);
+      }
+    });
+  }
 
-	@Override
-	public List<KeepercontainerTbl> findAllActiveByDcName(String dcName) {
-		return queryHandler.handleQuery(new DalQuery<List<KeepercontainerTbl>>() {
-			@Override
-			public List<KeepercontainerTbl> doQuery() throws DalException {
-				return dao.findActiveByDcName(dcName, KeepercontainerTblEntity.READSET_FULL);
-			}
-		});
-	}
+  @Override
+  public List<KeepercontainerTbl> findAllByDcName(final String dcName) {
+    return queryHandler.handleQuery(new DalQuery<List<KeepercontainerTbl>>() {
+      @Override
+      public List<KeepercontainerTbl> doQuery() throws DalException {
+        return dao.findByDcName(dcName, KeepercontainerTblEntity.READSET_FULL);
+      }
+    });
+  }
 
-	@Override
-	public List<KeepercontainerTbl> findKeeperCount(String dcName) {
-		return queryHandler.handleQuery(new DalQuery<List<KeepercontainerTbl>>() {
-			@Override
-			public List<KeepercontainerTbl> doQuery() throws DalException {
-				return dao.findKeeperCount(dcName, KeepercontainerTblEntity.READSET_KEEPER_COUNT);
-			}
-		});
-	}
+  @Override
+  public List<KeepercontainerTbl> findAllActiveByDcName(String dcName) {
+    return queryHandler.handleQuery(new DalQuery<List<KeepercontainerTbl>>() {
+      @Override
+      public List<KeepercontainerTbl> doQuery() throws DalException {
+        return dao.findActiveByDcName(dcName, KeepercontainerTblEntity.READSET_FULL);
+      }
+    });
+  }
 
-	@Override
-	public List<KeepercontainerTbl> findKeeperCountByClusterOrg(String dcName, long orgId) {
-		return queryHandler.handleQuery(new DalQuery<List<KeepercontainerTbl>>() {
-			@Override
-			public List<KeepercontainerTbl> doQuery() throws DalException {
-				return dao.findKeeperContainerByCluster(dcName, orgId, KeepercontainerTblEntity.READSET_KEEPER_COUNT_BY_CLUSTER);
-			}
-		});
-	}
+  @Override
+  public List<KeepercontainerTbl> findKeeperCount(String dcName) {
+    return queryHandler.handleQuery(new DalQuery<List<KeepercontainerTbl>>() {
+      @Override
+      public List<KeepercontainerTbl> doQuery() throws DalException {
+        return dao.findKeeperCount(dcName, KeepercontainerTblEntity.READSET_KEEPER_COUNT);
+      }
+    });
+  }
 
-	protected Void update(KeepercontainerTbl keepercontainerTbl){
+  @Override
+  public List<KeepercontainerTbl> findBestKeeperContainersByDcCluster(String dcName, String clusterName) {
+    /*
+     * 1. BU has its own keepercontainer(kc), then find all and see if it satisfied the requirement
+     * 2. Cluster don't have a BU, find default one
+     * 3. BU don't have its own kc, find in the normal kc pool(org id is 0L)
+     */
+    long clusterOrgId;
+    if (clusterName != null) {
+      ClusterTbl clusterTbl = clusterService.find(clusterName);
+      clusterOrgId = clusterTbl == null ? XPipeConsoleConstant.DEFAULT_ORG_ID : clusterTbl.getClusterOrgId();
+    } else {
+      clusterOrgId = XPipeConsoleConstant.DEFAULT_ORG_ID;
+    }
+    return queryHandler.handleQuery(new DalQuery<List<KeepercontainerTbl>>() {
+      @Override
+      public List<KeepercontainerTbl> doQuery() throws DalException {
+        List<KeepercontainerTbl> kcs = dao.findKeeperContainerByCluster(dcName, clusterOrgId,
+            KeepercontainerTblEntity.READSET_KEEPER_COUNT_BY_CLUSTER);
+        if (kcs == null || kcs.isEmpty()) {
+          kcs = dao.findKeeperContainerByCluster(dcName, XPipeConsoleConstant.DEFAULT_ORG_ID,
+              KeepercontainerTblEntity.READSET_KEEPER_COUNT_BY_CLUSTER);
+        }
+        return kcs;
+      }
+    });
+  }
 
-		return queryHandler.handleQuery(new DalQuery<Void>() {
-			@Override
-			public Void doQuery() throws DalException {
-				dao.updateByPK(keepercontainerTbl, KeepercontainerTblEntity.UPDATESET_FULL);
-				return null;
-			}
-		});
-	}
+  protected Void update(KeepercontainerTbl keepercontainerTbl) {
+
+    return queryHandler.handleQuery(new DalQuery<Void>() {
+      @Override
+      public Void doQuery() throws DalException {
+        dao.updateByPK(keepercontainerTbl, KeepercontainerTblEntity.UPDATESET_FULL);
+        return null;
+      }
+    });
+  }
 }

--- a/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/service/impl/KeepercontainerServiceImpl.java
+++ b/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/service/impl/KeepercontainerServiceImpl.java
@@ -55,6 +55,15 @@ public class KeepercontainerServiceImpl extends AbstractConsoleService<Keepercon
 		});
 	}
 
+	@Override
+	public List<KeepercontainerTbl> findKeeperCountByClusterOrg(String dcName, long orgId) {
+		return queryHandler.handleQuery(new DalQuery<List<KeepercontainerTbl>>() {
+			@Override
+			public List<KeepercontainerTbl> doQuery() throws DalException {
+				return dao.findKeeperContainerByCluster(dcName, orgId, KeepercontainerTblEntity.READSET_KEEPER_COUNT_BY_CLUSTER);
+			}
+		});
+	}
 
 	protected Void update(KeepercontainerTbl keepercontainerTbl){
 

--- a/redis/redis-console/src/main/resources/META-INF/dal/jdbc/meta-codegen.xml
+++ b/redis/redis-console/src/main/resources/META-INF/dal/jdbc/meta-codegen.xml
@@ -10,6 +10,9 @@
     <member name="data-change-last-time" field="DataChange_LastTime" value-type="Date" nullable="false" />
     <member name="deleted" field="deleted" value-type="boolean" nullable="false" />
     <member name="is-xpipe-interested" field="is_xpipe_interested" value-type="boolean" nullable="false" />
+    <member name="cluster-org-id" field="cluster_org_id" value-type="long" length="20" nullable="false" />
+    <member name="cluster-connector-names" field="cluster_connector_names" value-type="String" length="128" nullable="false" />
+    <member name="cluster-connector-emails" field="cluster_connector_emails" value-type="String" length="128" nullable="false" />
     <var name="key-id" value-type="long" key-member="id" />
     <primary-key name="PRIMARY" members="id" />
     <index name="cluster_name" unique="true" members="cluster_name ASC" />
@@ -181,6 +184,7 @@
     <member name="keepercontainer-active" field="keepercontainer_active" value-type="boolean" nullable="false" />
     <member name="data-change-last-time" field="DataChange_LastTime" value-type="Date" nullable="false" />
     <member name="deleted" field="deleted" value-type="boolean" nullable="false" />
+    <member name="keepercontainer-org-id" field="keepercontainer_org_id" value-type="long" length="20" nullable="false" />
     <var name="key-keepercontainer-id" value-type="long" key-member="keepercontainer-id" />
     <primary-key name="PRIMARY" members="keepercontainer_id" />
     <index name="DataChange_LastTime" members="DataChange_LastTime ASC" />
@@ -525,6 +529,47 @@
     <member name="deleted" field="deleted" value-type="int" length="3" nullable="false" />
     <var name="key-id" value-type="long" key-member="id" />
     <primary-key name="PRIMARY" members="id" />
+    <index name="DataChange_LastTime" members="DataChange_LastTime ASC" />
+    <readsets>
+      <readset name="FULL" all="true" />
+    </readsets>
+    <updatesets>
+      <updateset name="FULL" all="true" />
+    </updatesets>
+    <query-defs>
+      <query name="find-by-PK" type="SELECT">
+        <param name="key-id" />
+        <statement><![CDATA[SELECT <FIELDS/>
+        FROM <TABLE/>
+        WHERE <FIELD name='id'/> = ${key-id}]]></statement>
+      </query>
+      <query name="insert" type="INSERT">
+        <statement><![CDATA[INSERT INTO <TABLE/>(<FIELDS/>)
+        VALUES(<VALUES/>)]]></statement>
+      </query>
+      <query name="update-by-PK" type="UPDATE">
+        <param name="key-id" />
+        <statement><![CDATA[UPDATE <TABLE/>
+        SET <FIELDS/>
+        WHERE <FIELD name='id'/> = ${key-id}]]></statement>
+      </query>
+      <query name="delete-by-PK" type="DELETE">
+        <param name="key-id" />
+        <statement><![CDATA[DELETE FROM <TABLE/>
+        WHERE <FIELD name='id'/> = ${key-id}]]></statement>
+      </query>
+    </query-defs>
+  </entity>
+  <entity name="organization-tbl" table="organization_tbl" alias="ot">
+    <member name="id" field="id" value-type="long" length="20" nullable="false" key="true" auto-increment="true" />
+    <member name="org-id" field="org_id" value-type="long" length="20" nullable="false" />
+    <member name="org-name" field="org_name" value-type="String" length="1024" nullable="false" />
+    <member name="data-change-last-time" field="DataChange_LastTime" value-type="Date" nullable="false" />
+    <member name="deleted" field="deleted" value-type="int" length="3" nullable="false" />
+    <var name="key-id" value-type="long" key-member="id" />
+    <primary-key name="PRIMARY" members="id" />
+    <index name="org_id" unique="true" members="org_id ASC" />
+    <index name="org_name" unique="true" members="org_name ASC" />
     <index name="DataChange_LastTime" members="DataChange_LastTime ASC" />
     <readsets>
       <readset name="FULL" all="true" />

--- a/redis/redis-console/src/main/resources/META-INF/dal/jdbc/meta-codegen.xml
+++ b/redis/redis-console/src/main/resources/META-INF/dal/jdbc/meta-codegen.xml
@@ -11,7 +11,6 @@
     <member name="deleted" field="deleted" value-type="boolean" nullable="false" />
     <member name="is-xpipe-interested" field="is_xpipe_interested" value-type="boolean" nullable="false" />
     <member name="cluster-org-id" field="cluster_org_id" value-type="long" length="20" nullable="false" />
-    <member name="cluster-admin-names" field="cluster_admin_names" value-type="String" length="128" />
     <member name="cluster-admin-emails" field="cluster_admin_emails" value-type="String" length="128" />
     <var name="key-id" value-type="long" key-member="id" />
     <primary-key name="PRIMARY" members="id" />

--- a/redis/redis-console/src/main/resources/META-INF/dal/jdbc/meta-codegen.xml
+++ b/redis/redis-console/src/main/resources/META-INF/dal/jdbc/meta-codegen.xml
@@ -11,8 +11,8 @@
     <member name="deleted" field="deleted" value-type="boolean" nullable="false" />
     <member name="is-xpipe-interested" field="is_xpipe_interested" value-type="boolean" nullable="false" />
     <member name="cluster-org-id" field="cluster_org_id" value-type="long" length="20" nullable="false" />
-    <member name="cluster-connector-names" field="cluster_connector_names" value-type="String" length="128" nullable="false" />
-    <member name="cluster-connector-emails" field="cluster_connector_emails" value-type="String" length="128" nullable="false" />
+    <member name="cluster-admin-names" field="cluster_admin_names" value-type="String" length="128" />
+    <member name="cluster-admin-emails" field="cluster_admin_emails" value-type="String" length="128" />
     <var name="key-id" value-type="long" key-member="id" />
     <primary-key name="PRIMARY" members="id" />
     <index name="cluster_name" unique="true" members="cluster_name ASC" />

--- a/redis/redis-console/src/main/resources/META-INF/dal/jdbc/meta-dal.xml
+++ b/redis/redis-console/src/main/resources/META-INF/dal/jdbc/meta-dal.xml
@@ -508,6 +508,11 @@
 	</entity>
 
 	<entity name="redis-tbl" table="REDIS_TBL" alias="rt">
+		<!-- Add two constant below to fix bug, that when use h2 db in unit/integration test -->
+		<!-- RedisService.updateRedis() will fail, due to h2 db not recognize sequential insert with id of 0 -->
+		<member name="id" field="id" value-type="Long" length="20" nullable="true" key="true" auto-increment="true" />
+		<var name="key-id" value-type="Long" key-member="id" />
+
 		<var name="dc-name" value-type="String"/>
 		<var name="cluster-name" value-type="String"/>
 

--- a/redis/redis-console/src/main/resources/META-INF/dal/jdbc/meta-dal.xml
+++ b/redis/redis-console/src/main/resources/META-INF/dal/jdbc/meta-dal.xml
@@ -765,7 +765,7 @@
 
 	<entity name="keepercontainer-tbl" table="KEEPERCONTAINER_TBL" alias="kt">
 		<var name="dc-name" value-type="String"/>
-		<var name="org-id" value-type="Long"/>
+		<var name="org-id" value-type="long"/>
 
 		<member name="count" value-type="long" select-expr="COUNT(*) count" all="false"/>
 
@@ -778,11 +778,15 @@
 				<member name='keepercontainer-ip'/>
 				<member name="count"/>
 			</readset>
-			<readset name="">
+
+			<readset name="KEEPER_COUNT_BY_CLUSTER">
 				<member name='keepercontainer-id'/>
 				<member name='keepercontainer-ip'/>
+				<member name='keepercontainer-port'/>
+				<member name="keepercontainer-active"/>
+				<member name="keepercontainer-dc"/>
 				<member name="count"/>
-				<member name="org-id"/>
+				<member name="keepercontainer-org-id" />
 			</readset>
 		</readsets>
 		<query-defs>

--- a/redis/redis-console/src/main/resources/META-INF/dal/jdbc/meta-dal.xml
+++ b/redis/redis-console/src/main/resources/META-INF/dal/jdbc/meta-dal.xml
@@ -765,6 +765,7 @@
 
 	<entity name="keepercontainer-tbl" table="KEEPERCONTAINER_TBL" alias="kt">
 		<var name="dc-name" value-type="String"/>
+		<var name="org-id" value-type="Long"/>
 
 		<member name="count" value-type="long" select-expr="COUNT(*) count" all="false"/>
 
@@ -776,6 +777,12 @@
 				<member name='keepercontainer-id'/>
 				<member name='keepercontainer-ip'/>
 				<member name="count"/>
+			</readset>
+			<readset name="">
+				<member name='keepercontainer-id'/>
+				<member name='keepercontainer-ip'/>
+				<member name="count"/>
+				<member name="org-id"/>
 			</readset>
 		</readsets>
 		<query-defs>
@@ -817,6 +824,24 @@
 					AND <FIELD name='keepercontainer-active'/> = 1
 					AND (kit.deleted = 0 or kit.deleted is null)
 					AND <FIELD name='deleted'/> = 0
+					GROUP BY <FIELD name='keepercontainer-id'/>
+					order by count
+					]]>
+				</statement>
+			</query>
+			<query name="find-keeper-container-by-cluster" type="SELECT" multiple="true">
+				<param name="dc-name"/>
+				<param name="org-id" />
+				<statement>
+					<![CDATA[
+					SELECT <FIELDS/>
+					FROM <TABLE/> left join  <TABLE name='keeper-info'/> on <FIELD name='keepercontainer-id'/> = kit.keepercontainer_id , <TABLE name='dc-info'/>
+					WHERE <FIELD name='keepercontainer-dc'/> = dt.id
+					AND dt.dc_name = ${dc-name}
+					AND <FIELD name='keepercontainer-active'/> = 1
+					AND (kit.deleted = 0 or kit.deleted is null)
+					AND <FIELD name='deleted'/> = 0
+					AND <FIELD name='keepercontainer-org-id'/> = ${org-id}
 					GROUP BY <FIELD name='keepercontainer-id'/>
 					order by count
 					]]>

--- a/redis/redis-console/src/main/resources/META-INF/plexus/components.xml
+++ b/redis/redis-console/src/main/resources/META-INF/plexus/components.xml
@@ -118,6 +118,15 @@
 			</configuration>
 		</component>
 		<component>
+			<role>org.unidal.dal.jdbc.mapping.TableProvider</role>
+			<role-hint>organization-tbl</role-hint>
+			<implementation>org.unidal.dal.jdbc.mapping.SimpleTableProvider</implementation>
+			<configuration>
+				<physical-table-name>organization_tbl</physical-table-name>
+				<data-source-name>fxxpipe</data-source-name>
+			</configuration>
+		</component>
+		<component>
 			<role>com.ctrip.xpipe.redis.console.model.ClusterTblDao</role>
 			<implementation>com.ctrip.xpipe.redis.console.model.ClusterTblDao</implementation>
 			<requirements>
@@ -228,6 +237,15 @@
 		<component>
 			<role>com.ctrip.xpipe.redis.console.model.MigrationShardTblDao</role>
 			<implementation>com.ctrip.xpipe.redis.console.model.MigrationShardTblDao</implementation>
+			<requirements>
+				<requirement>
+					<role>org.unidal.dal.jdbc.QueryEngine</role>
+				</requirement>
+			</requirements>
+		</component>
+		<component>
+			<role>com.ctrip.xpipe.redis.console.model.OrganizationTblDao</role>
+			<implementation>com.ctrip.xpipe.redis.console.model.OrganizationTblDao</implementation>
 			<requirements>
 				<requirement>
 					<role>org.unidal.dal.jdbc.QueryEngine</role>

--- a/redis/redis-console/src/main/resources/META-INF/wizard/jdbc/wizard.xml
+++ b/redis/redis-console/src/main/resources/META-INF/wizard/jdbc/wizard.xml
@@ -5,7 +5,7 @@
          <driver>com.mysql.jdbc.Driver</driver>
          <url>jdbc:mysql://localhost:3306/fxxpipedb</url>
          <user>root</user>
-         <password>root</password>
+         <password>12345678</password>
          <properties>useUnicode=true&amp;characterEncoding=UTF-8&amp;autoReconnect=true</properties>
       </datasource>
       <group name="meta" package="com.ctrip.xpipe.redis.console.model">
@@ -22,6 +22,7 @@
          <table name="migration_event_tbl"/>
          <table name="migration_shard_tbl"/>
          <table name="config_tbl"/>
+         <table name="organization_tbl"/>
       </group>
    </jdbc>
 </wizard>

--- a/redis/redis-console/src/main/resources/sql/h2/xpipedemodbinitdata.sql
+++ b/redis/redis-console/src/main/resources/sql/h2/xpipedemodbinitdata.sql
@@ -10,9 +10,3 @@ insert into KEEPERCONTAINER_TBL(keepercontainer_id,keepercontainer_dc,keepercont
 insert into KEEPERCONTAINER_TBL(keepercontainer_id,keepercontainer_dc,keepercontainer_ip,keepercontainer_port,keepercontainer_active) values (4,2,'127.0.0.1',7180,1);
 insert into KEEPERCONTAINER_TBL(keepercontainer_id,keepercontainer_dc,keepercontainer_ip,keepercontainer_port,keepercontainer_active) values (5,2,'127.0.0.1',7181,1);
 insert into KEEPERCONTAINER_TBL(keepercontainer_id,keepercontainer_dc,keepercontainer_ip,keepercontainer_port,keepercontainer_active) values (6,2,'127.0.0.1',7182,1);
-
-
-insert into KEEPERCONTAINER_TBL(keepercontainer_id,keepercontainer_dc,keepercontainer_ip,keepercontainer_port,keepercontainer_active, keepercontainer_org_id) values (7,1,'127.0.0.2',7083,1,2);
-insert into KEEPERCONTAINER_TBL(keepercontainer_id,keepercontainer_dc,keepercontainer_ip,keepercontainer_port,keepercontainer_active, keepercontainer_org_id) values (8,1,'127.0.0.2',7084,1,2);
-insert into KEEPERCONTAINER_TBL(keepercontainer_id,keepercontainer_dc,keepercontainer_ip,keepercontainer_port,keepercontainer_active, keepercontainer_org_id) values (9,2,'127.0.0.2',7083,1,2);
-insert into KEEPERCONTAINER_TBL(keepercontainer_id,keepercontainer_dc,keepercontainer_ip,keepercontainer_port,keepercontainer_active, keepercontainer_org_id) values (10,2,'127.0.0.2',7084,1,2);

--- a/redis/redis-console/src/main/resources/sql/h2/xpipedemodbinitdata.sql
+++ b/redis/redis-console/src/main/resources/sql/h2/xpipedemodbinitdata.sql
@@ -10,3 +10,9 @@ insert into KEEPERCONTAINER_TBL(keepercontainer_id,keepercontainer_dc,keepercont
 insert into KEEPERCONTAINER_TBL(keepercontainer_id,keepercontainer_dc,keepercontainer_ip,keepercontainer_port,keepercontainer_active) values (4,2,'127.0.0.1',7180,1);
 insert into KEEPERCONTAINER_TBL(keepercontainer_id,keepercontainer_dc,keepercontainer_ip,keepercontainer_port,keepercontainer_active) values (5,2,'127.0.0.1',7181,1);
 insert into KEEPERCONTAINER_TBL(keepercontainer_id,keepercontainer_dc,keepercontainer_ip,keepercontainer_port,keepercontainer_active) values (6,2,'127.0.0.1',7182,1);
+
+
+insert into KEEPERCONTAINER_TBL(keepercontainer_id,keepercontainer_dc,keepercontainer_ip,keepercontainer_port,keepercontainer_active, keepercontainer_org_id) values (7,1,'127.0.0.2',7083,1,2);
+insert into KEEPERCONTAINER_TBL(keepercontainer_id,keepercontainer_dc,keepercontainer_ip,keepercontainer_port,keepercontainer_active, keepercontainer_org_id) values (8,1,'127.0.0.2',7084,1,2);
+insert into KEEPERCONTAINER_TBL(keepercontainer_id,keepercontainer_dc,keepercontainer_ip,keepercontainer_port,keepercontainer_active, keepercontainer_org_id) values (9,2,'127.0.0.2',7083,1,2);
+insert into KEEPERCONTAINER_TBL(keepercontainer_id,keepercontainer_dc,keepercontainer_ip,keepercontainer_port,keepercontainer_active, keepercontainer_org_id) values (10,2,'127.0.0.2',7084,1,2);

--- a/redis/redis-console/src/main/resources/sql/h2/xpipedemodbtables.sql
+++ b/redis/redis-console/src/main/resources/sql/h2/xpipedemodbtables.sql
@@ -54,9 +54,9 @@ create table CLUSTER_TBL
     DataChange_LastTime timestamp default CURRENT_TIMESTAMP,
 	deleted tinyint(1) not null default 0,
 	is_xpipe_interested tinyint(1) default 0,
-	cluster_org_id bigint(20) unsigned NOT NULL DEFAULT 0,
-	cluster_connector_names varchar(128)  NOT NULL DEFAULT 'default',
-    cluster_connector_emails varchar(128)  NOT NULL DEFAULT 'default'
+	cluster_org_id bigint unsigned not null default 0,
+	cluster_admin_names varchar(128) default 'default',
+    cluster_admin_emails varchar(128) default 'default'
 );
 
 
@@ -190,10 +190,10 @@ INSERT INTO config_tbl (`key`, `value`, `desc`) VALUES ('sentinel.auto.process',
 -- Organization Table
 drop table if exists organization_tbl;
 CREATE TABLE `organization_tbl` (
-  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT primary key,
-  `org_id`  bigint(20) unsigned NOT NULL DEFAULT 0 unique,
-  `org_name` varchar(1024) NOT NULL DEFAULT 'none' unique,
-  `DataChange_LastTime` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  `deleted` tinyint(4) NOT NULL DEFAULT 0,
+  id bigint(20) unsigned not null AUTO_INCREMENT primary key,
+  org_id  bigint(20) unsigned not null default 0 unique,
+  org_name varchar(1024) not null default 'none' unique,
+  DataChange_LastTime timestamp default CURRENT_TIMESTAMP,
+  deleted tinyint(4) not null default 0,
 );
 INSERT INTO organization_tbl (`org_id`, `org_name`) VALUES ('0', 'default');

--- a/redis/redis-console/src/main/resources/sql/h2/xpipedemodbtables.sql
+++ b/redis/redis-console/src/main/resources/sql/h2/xpipedemodbtables.sql
@@ -55,8 +55,7 @@ create table CLUSTER_TBL
 	deleted tinyint(1) not null default 0,
 	is_xpipe_interested tinyint(1) default 0,
 	cluster_org_id bigint unsigned not null default 0,
-	cluster_admin_names varchar(128) default 'default',
-    cluster_admin_emails varchar(128) default 'default'
+    cluster_admin_emails varchar(128) default ' '
 );
 
 

--- a/redis/redis-console/src/main/resources/sql/h2/xpipedemodbtables.sql
+++ b/redis/redis-console/src/main/resources/sql/h2/xpipedemodbtables.sql
@@ -53,7 +53,10 @@ create table CLUSTER_TBL
     status varchar(24) not null default 'normal',
     DataChange_LastTime timestamp default CURRENT_TIMESTAMP,
 	deleted tinyint(1) not null default 0,
-	is_xpipe_interested tinyint(1) default 0
+	is_xpipe_interested tinyint(1) default 0,
+	cluster_org_id bigint(20) unsigned NOT NULL DEFAULT 0,
+	cluster_connector_names varchar(128)  NOT NULL DEFAULT 'default',
+    cluster_connector_emails varchar(128)  NOT NULL DEFAULT 'default'
 );
 
 
@@ -126,7 +129,8 @@ create table KEEPERCONTAINER_TBL
 	keepercontainer_port int not null,
 	keepercontainer_active tinyint(1) not null default 1,
     DataChange_LastTime timestamp default CURRENT_TIMESTAMP,
-	deleted tinyint(1) not null default 0
+	deleted tinyint(1) not null default 0,
+	keepercontainer_org_id bigint(20) unsigned NOT NULL DEFAULT 0
 );
 
 -- Migration Event Table
@@ -183,3 +187,13 @@ CREATE TABLE `config_tbl` (
 );
 INSERT INTO config_tbl (`key`, `value`, `desc`) VALUES ('sentinel.auto.process', 'true', '自动增删哨兵');
 
+-- Organization Table
+drop table if exists organization_tbl;
+CREATE TABLE `organization_tbl` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT primary key,
+  `org_id`  bigint(20) unsigned NOT NULL DEFAULT 0 unique,
+  `org_name` varchar(1024) NOT NULL DEFAULT 'none' unique,
+  `DataChange_LastTime` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `deleted` tinyint(4) NOT NULL DEFAULT 0,
+);
+INSERT INTO organization_tbl (`org_id`, `org_name`) VALUES ('0', 'default');

--- a/redis/redis-console/src/main/resources/sql/mysql/xpipedemodbtables.sql
+++ b/redis/redis-console/src/main/resources/sql/mysql/xpipedemodbtables.sql
@@ -63,6 +63,10 @@ CREATE TABLE `CLUSTER_TBL` (
   `DataChange_LastTime` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'last modified time',
   `deleted` tinyint(1) NOT NULL DEFAULT '0' COMMENT 'deleted or not',
   `is_xpipe_interested` tinyint(1) NOT NULL DEFAULT '0' COMMENT 'is xpipe interested',
+  `cluster_org_id` bigint(20) unsigned NOT NULL DEFAULT '0' COMMENT 'organization id of cluster',
+  `cluster_connector_names` varchar(128)  NOT NULL DEFAULT 'default' COMMENT 'persons who in charge of this cluster',
+  `cluster_connector_emails` varchar(128)  NOT NULL DEFAULT 'default' COMMENT 'persons email who in charge of this cluster',
+
   PRIMARY KEY (`id`),
   UNIQUE KEY `cluster_name` (`cluster_name`),
   KEY `DataChange_LastTime` (`DataChange_LastTime`),
@@ -154,6 +158,7 @@ CREATE TABLE `KEEPERCONTAINER_TBL` (
   `keepercontainer_active` tinyint(1) NOT NULL DEFAULT '1' COMMENT 'keepercontainer active status',
   `DataChange_LastTime` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'last modified time',
   `deleted` tinyint(1) NOT NULL DEFAULT '0' COMMENT 'deleted or not',
+  `keepercontainer_org_id` bigint(20) unsigned NOT NULL DEFAULT '0' COMMENT 'organization id of keeper container',
   PRIMARY KEY (`keepercontainer_id`),
   KEY `DataChange_LastTime` (`DataChange_LastTime`),
   KEY `keepercontainer_dc` (`keepercontainer_dc`)
@@ -227,3 +232,17 @@ CREATE TABLE `config_tbl` (
 
 INSERT INTO config_tbl (`key`, `value`, `desc`) VALUES ('sentinel.auto.process', 'true', '自动增删哨兵');
 
+-- Organization Table
+drop table if exists organization_tbl;
+CREATE TABLE `organization_tbl` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'primary key',
+  `org_id`  bigint(20) unsigned NOT NULL DEFAULT '0' COMMENT 'organization id',
+  `org_name` varchar(1024) NOT NULL DEFAULT 'none' COMMENT 'organization name',
+  `DataChange_LastTime` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'data changed last time',
+  `deleted` tinyint(4) NOT NULL DEFAULT '0' COMMENT 'deleted or not',
+  PRIMARY KEY (`id`),
+  KEY `DataChange_LastTime` (`DataChange_LastTime`),
+  UNIQUE KEY `org_id` (`org_id`),
+  UNIQUE KEY `org_name` (`org_name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Organization Info';
+INSERT INTO organization_tbl (`org_id`, `org_name`) VALUES ('0', 'default');

--- a/redis/redis-console/src/main/resources/sql/mysql/xpipedemodbtables.sql
+++ b/redis/redis-console/src/main/resources/sql/mysql/xpipedemodbtables.sql
@@ -64,8 +64,8 @@ CREATE TABLE `CLUSTER_TBL` (
   `deleted` tinyint(1) NOT NULL DEFAULT '0' COMMENT 'deleted or not',
   `is_xpipe_interested` tinyint(1) NOT NULL DEFAULT '0' COMMENT 'is xpipe interested',
   `cluster_org_id` bigint(20) unsigned NOT NULL DEFAULT '0' COMMENT 'organization id of cluster',
-  `cluster_connector_names` varchar(128)  NOT NULL DEFAULT 'default' COMMENT 'persons who in charge of this cluster',
-  `cluster_connector_emails` varchar(128)  NOT NULL DEFAULT 'default' COMMENT 'persons email who in charge of this cluster',
+  `cluster_admin_names` varchar(128)  DEFAULT ' ' COMMENT 'persons who in charge of this cluster',
+  `cluster_admin_emails` varchar(128) DEFAULT ' ' COMMENT 'persons email who in charge of this cluster',
 
   PRIMARY KEY (`id`),
   UNIQUE KEY `cluster_name` (`cluster_name`),

--- a/redis/redis-console/src/main/resources/sql/mysql/xpipedemodbtables.sql
+++ b/redis/redis-console/src/main/resources/sql/mysql/xpipedemodbtables.sql
@@ -64,7 +64,6 @@ CREATE TABLE `CLUSTER_TBL` (
   `deleted` tinyint(1) NOT NULL DEFAULT '0' COMMENT 'deleted or not',
   `is_xpipe_interested` tinyint(1) NOT NULL DEFAULT '0' COMMENT 'is xpipe interested',
   `cluster_org_id` bigint(20) unsigned NOT NULL DEFAULT '0' COMMENT 'organization id of cluster',
-  `cluster_admin_names` varchar(128)  DEFAULT ' ' COMMENT 'persons who in charge of this cluster',
   `cluster_admin_emails` varchar(128) DEFAULT ' ' COMMENT 'persons email who in charge of this cluster',
 
   PRIMARY KEY (`id`),

--- a/redis/redis-console/src/main/resources/static/scripts/controllers/ClusterDcShardUpdateCtl.js
+++ b/redis/redis-console/src/main/resources/static/scripts/controllers/ClusterDcShardUpdateCtl.js
@@ -106,7 +106,6 @@ index_module.controller('ClusterDcShardUpdateCtl',
                              }
 
                              function createRedis() {
-//                                 $scope.toCreateRedis.id = 0;
                                  var shard = $scope.dcShards[$scope.currentDcName];
                                  shard.redises.push($scope.toCreateRedis);
                                  $scope.toCreateRedis = {};
@@ -167,7 +166,6 @@ index_module.controller('ClusterDcShardUpdateCtl',
                                     			 break;
                                     		 }
                                     	 }
-//                                    	 $scope.toCreateFirstKeeper.id = 0;
                                          shard.keepers.push($scope.toCreateFirstKeeper);
                                      }
 
@@ -183,7 +181,6 @@ index_module.controller('ClusterDcShardUpdateCtl',
                                     			 break;
                                     		 }
                                     	 }
-//                                    	 otherKeeper.id = 0;
                                          shard.keepers.push(otherKeeper);
                                      }
                                  });

--- a/redis/redis-console/src/main/resources/static/scripts/controllers/ClusterDcShardUpdateCtl.js
+++ b/redis/redis-console/src/main/resources/static/scripts/controllers/ClusterDcShardUpdateCtl.js
@@ -108,7 +108,7 @@ index_module.controller('ClusterDcShardUpdateCtl',
                              }
 
                              function createRedis() {
-                                 $scope.toCreateRedis.id = 0;
+//                                 $scope.toCreateRedis.id = 0;
                                  var shard = $scope.dcShards[$scope.currentDcName];
                                  shard.redises.push($scope.toCreateRedis);
                                  $scope.toCreateRedis = {};
@@ -170,7 +170,7 @@ index_module.controller('ClusterDcShardUpdateCtl',
                                     			 break;
                                     		 }
                                     	 }
-                                    	 $scope.toCreateFirstKeeper.id = 0;
+//                                    	 $scope.toCreateFirstKeeper.id = 0;
                                          shard.keepers.push($scope.toCreateFirstKeeper);
                                      }
 
@@ -186,7 +186,7 @@ index_module.controller('ClusterDcShardUpdateCtl',
                                     			 break;
                                     		 }
                                     	 }
-                                    	 otherKeeper.id = 0;
+//                                    	 otherKeeper.id = 0;
                                          shard.keepers.push(otherKeeper);
                                      }
                                  });

--- a/redis/redis-console/src/main/resources/static/scripts/controllers/ClusterDcShardUpdateCtl.js
+++ b/redis/redis-console/src/main/resources/static/scripts/controllers/ClusterDcShardUpdateCtl.js
@@ -32,21 +32,19 @@ index_module.controller('ClusterDcShardUpdateCtl',
                                  loadCluster();
                              }
 
-                             function findActiveKeeperContainers(dcName) {
-                                 KeeperContainerService.findActiveKeeperContainersByDc(dcName)
-                                     .then(function (result) {
-                                    	 result.sort(function(keeperA, keeperB) {
-                                    		 return keeperA.keepercontainerIp.localeCompare(keeperB.keepercontainerIp);
-                                    	 });
-                                         $scope.keeperContainers = result;
-                                     })
-
+                             function findActiveKeeperContainersByCluster(dcName, clusterName) {
+                                 KeeperContainerService.findAvailableKeepersByDcAndCluster(dcName, clusterName)
+                                    .then(function(result) {
+                                         result.sort(function(keeperA, keeperB) {
+                                             return keeperA.count - keeperB.count;
+                                         });
+                                            $scope.keeperContainers = result;
+                                        })
                              }
 
                              function switchDc(dc) {
                                  $scope.currentDcName = dc.dcName;
-                                 findActiveKeeperContainers($scope.currentDcName);
-
+                                 findActiveKeeperContainersByCluster($scope.currentDcName, $scope.clusterName);
                                  var shard = $scope.dcShards[$scope.currentDcName];
 
                                  if (!shard){
@@ -78,7 +76,7 @@ index_module.controller('ClusterDcShardUpdateCtl',
                                  	 		});
                                          
                                          if(!$scope.currentDcName) $scope.currentDcName = $scope.dcs[0].dcName;
-                                         findActiveKeeperContainers($scope.currentDcName);
+                                         findActiveKeeperContainersByCluster($scope.currentDcName, $scope.clusterName);
                                          loadShard($scope.clusterName, $scope.currentDcName, $scope.shardName);
 
                                      }, function (result) {
@@ -126,7 +124,7 @@ index_module.controller('ClusterDcShardUpdateCtl',
                              }
 
                              function preCreateKeeper() {
-
+                                 $scope.orgSpecifiedKeepers = [];
                                  $scope.toCreateFirstKeeper = {
                                  };
                                  // init backup container
@@ -134,7 +132,6 @@ index_module.controller('ClusterDcShardUpdateCtl',
 
                                  var shard = $scope.dcShards[$scope.currentDcName];
                                   KeeperContainerService.findAvailableKeepersByDc($scope.currentDcName, shard).then(function(keepers){
-
                                      var keeper = keepers.shift();
                                      if(keeper){
                                          $scope.toCreateFirstKeeper = {

--- a/redis/redis-console/src/main/resources/static/scripts/services/KeeperContainerService.js
+++ b/redis/redis-console/src/main/resources/static/scripts/services/KeeperContainerService.js
@@ -1,17 +1,21 @@
 services.service('KeeperContainerService', ['$resource', '$q', function ($resource, $q) {
 
     var resource = $resource('', {}, {
-        find_activekeepercontainers_by_dc: {
-            method: 'GET',
-            url: '/console/dcs/:dcName/activekeepercontainers',
-            isArray : true
-        },
+//        find_activekeepercontainers_by_dc: {
+//            method: 'GET',
+//            url: '/console/dcs/:dcName/activekeepercontainers',
+//            isArray : true
+//        },
         find_availablekeepers_by_dc: {
             method: 'POST',
             url: '/console/dcs/:dcName/availablekeepers',
             isArray : true
+        },
+        find_active_kcs_by_dc_and_cluster: {
+            method: 'GET',
+            url: '/console/dcs/:dcName/cluster/:clusterName/activekeepercontainers',
+            isArray : true
         }
-
     });
 
     function findActiveKeeperContainersByDc(dcName) {
@@ -40,8 +44,22 @@ services.service('KeeperContainerService', ['$resource', '$q', function ($resour
         return d.promise;
     }
 
+    function findAvailableKeepersByDcAndCluster(dcName, clusterName) {
+            var d = $q.defer();
+            resource.find_active_kcs_by_dc_and_cluster({
+                                dcName: dcName,
+                                clusterName: clusterName
+                            },
+                            function (result) {
+                                d.resolve(result);
+                            }, function (result) {
+                    d.reject(result);
+                });
+            return d.promise;
+    }
+
     return {
-        findActiveKeeperContainersByDc : findActiveKeeperContainersByDc,
-        findAvailableKeepersByDc : findAvailableKeepersByDc
+        findAvailableKeepersByDc : findAvailableKeepersByDc,
+        findAvailableKeepersByDcAndCluster : findAvailableKeepersByDcAndCluster
     }
 }]);

--- a/redis/redis-console/src/main/resources/static/scripts/services/KeeperContainerService.js
+++ b/redis/redis-console/src/main/resources/static/scripts/services/KeeperContainerService.js
@@ -1,11 +1,6 @@
 services.service('KeeperContainerService', ['$resource', '$q', function ($resource, $q) {
 
     var resource = $resource('', {}, {
-//        find_activekeepercontainers_by_dc: {
-//            method: 'GET',
-//            url: '/console/dcs/:dcName/activekeepercontainers',
-//            isArray : true
-//        },
         find_availablekeepers_by_dc: {
             method: 'POST',
             url: '/console/dcs/:dcName/availablekeepers',

--- a/redis/redis-console/src/test/java/com/ctrip/xpipe/redis/console/controller/api/data/KeeperUpdateControllerTest.java
+++ b/redis/redis-console/src/test/java/com/ctrip/xpipe/redis/console/controller/api/data/KeeperUpdateControllerTest.java
@@ -1,0 +1,54 @@
+package com.ctrip.xpipe.redis.console.controller.api.data;
+
+import com.ctrip.xpipe.redis.console.AbstractConsoleIntegrationTest;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.io.IOException;
+
+/**
+ * Created by zhuchen on 2017/8/29.
+ */
+public class KeeperUpdateControllerTest extends AbstractConsoleIntegrationTest {
+
+    @Autowired
+    KeeperUpdateController keeperUpdateController;
+
+    @Test
+    public void testAddKeepersWithNonKCForOrg() {
+        String dcName = "oy";
+        String clusterName = "cluster3";
+        String shardName = "cluster3shard1";
+        keeperUpdateController.addKeepers(dcName, clusterName, shardName);
+        for (String s : keeperUpdateController.getKeepers(dcName, clusterName, shardName)) {
+            logger.info(s);
+        }
+    }
+
+    @Test
+    public void testAddKeepersWithKCForOrg() {
+        String dcName = "jq";
+        String clusterName = "cluster2";
+        String shardName = "cluster2shard1";
+        keeperUpdateController.addKeepers(dcName, clusterName, shardName);
+        for (String s : keeperUpdateController.getKeepers(dcName, clusterName, shardName)) {
+            logger.info(s);
+        }
+    }
+
+    @Test
+    public void testAddKeepersWithDefaultOrg() {
+        String dcName = "jq";
+        String clusterName = "cluster1";
+        String shardName = "shard1";
+        keeperUpdateController.addKeepers(dcName, clusterName, shardName);
+        for (String s : keeperUpdateController.getKeepers(dcName, clusterName, shardName)) {
+            logger.info(s);
+        }
+    }
+
+    @Override
+    protected String prepareDatas() throws IOException {
+        return prepareDatasFromFile("src/test/resources/apptest.sql");
+    }
+}

--- a/redis/redis-console/src/test/java/com/ctrip/xpipe/redis/console/dao/ClusterDaoTest.java
+++ b/redis/redis-console/src/test/java/com/ctrip/xpipe/redis/console/dao/ClusterDaoTest.java
@@ -1,0 +1,38 @@
+package com.ctrip.xpipe.redis.console.dao;
+
+import com.ctrip.xpipe.redis.console.AbstractConsoleIntegrationTest;
+import com.ctrip.xpipe.redis.console.model.ClusterTbl;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.unidal.dal.jdbc.DalException;
+
+/**
+ * Created by zhuchen on 2017/8/26 0026.
+ */
+public class ClusterDaoTest  extends AbstractConsoleIntegrationTest {
+    @Autowired
+    ClusterDao clusterDao;
+
+    ClusterTbl clusterTbl;
+
+    @Before
+    public void beforeClusterDaoTest() {
+        clusterTbl = new ClusterTbl()
+                .setClusterDescription("ut-cluster")
+                .setActivedcId(1)
+                .setClusterName("ut-cluster")
+                .setCount(12)
+                .setIsXpipeInterested(true)
+                .setClusterLastModifiedTime("test-last-modified")
+                .setStatus("normal");
+    }
+
+
+    @Test
+    public void testCreateCluster() throws DalException {
+        ClusterTbl newCluster = clusterDao.createCluster(clusterTbl);
+        Assert.assertEquals(clusterTbl.getId(), newCluster.getId());
+    }
+}

--- a/redis/redis-console/src/test/java/com/ctrip/xpipe/redis/console/service/impl/KeepercontainerServiceImplTest.java
+++ b/redis/redis-console/src/test/java/com/ctrip/xpipe/redis/console/service/impl/KeepercontainerServiceImplTest.java
@@ -1,11 +1,16 @@
 package com.ctrip.xpipe.redis.console.service.impl;
 
+import com.ctrip.xpipe.redis.console.model.ClusterModel;
+import com.ctrip.xpipe.redis.console.model.ClusterTbl;
+import com.ctrip.xpipe.redis.console.model.DcTbl;
 import com.ctrip.xpipe.redis.console.model.KeepercontainerTbl;
+import com.google.common.collect.Lists;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.io.IOException;
 import java.util.List;
 
 /**
@@ -19,10 +24,8 @@ public class KeepercontainerServiceImplTest extends AbstractServiceImplTest{
     @Autowired
     private KeepercontainerServiceImpl keepercontainerService;
 
-
     @Before
-    public void beforeKeepercontainerServiceImplTest(){
-
+    public void beforeAbstractServiceImpl(){
     }
 
     @Test
@@ -36,16 +39,30 @@ public class KeepercontainerServiceImplTest extends AbstractServiceImplTest{
     }
 
     @Test
-    public void testFindKeeperCountByCluster() {
+    public void testFindKeeperCountByClusterWithBUSpecified() {
+        String clusterName = "cluster2";
         long orgId = 2L;
-        List<KeepercontainerTbl> keeperCount = keepercontainerService.findKeeperCountByClusterOrg(dcNames[0], orgId);
+        List<KeepercontainerTbl> keeperCount = keepercontainerService.findBestKeeperContainersByDcCluster(dcNames[0], clusterName);
         keeperCount.forEach(kc -> logger.info("{}", kc));
         Assert.assertTrue(keeperCount.stream().allMatch(kc->kc.getKeepercontainerOrgId() == orgId));
-        logger.info("------------------------------------------------------------------");
-        long noneOrgId = 0L;
-        keeperCount = keepercontainerService.findKeeperCountByClusterOrg(dcNames[0], noneOrgId);
+    }
+
+    @Test
+    public void testFindKeeperCountByClusterWithNoneBUSpecified() {
+        String clusterName = "cluster1";
+        long orgId = 0L;
+        List<KeepercontainerTbl> keeperCount = keepercontainerService.findBestKeeperContainersByDcCluster(dcNames[0], clusterName);
         keeperCount.forEach(kc -> logger.info("{}", kc));
-        Assert.assertTrue(keeperCount.stream().allMatch(kc->kc.getKeepercontainerOrgId() == noneOrgId));
+        Assert.assertTrue(keeperCount.stream().allMatch(kc->kc.getKeepercontainerOrgId() == orgId));
+    }
+
+    @Test
+    public void testFindKeeperCountByClusterWithNoKCForBU() {
+        String clusterName = "cluster3";
+        long orgId = 0L;
+        List<KeepercontainerTbl> keeperCount = keepercontainerService.findBestKeeperContainersByDcCluster(dcNames[0], clusterName);
+        keeperCount.forEach(kc -> logger.info("{}", kc));
+        Assert.assertTrue(keeperCount.stream().allMatch(kc->kc.getKeepercontainerOrgId() == orgId));
     }
 
     @Test
@@ -69,5 +86,10 @@ public class KeepercontainerServiceImplTest extends AbstractServiceImplTest{
         allByDcName = keepercontainerService.findAllByDcName(dcName);
         Assert.assertEquals(size, allByDcName.size());
 
+    }
+
+    @Override
+    protected String prepareDatas() throws IOException {
+        return prepareDatasFromFile("src/test/resources/apptest.sql");
     }
 }

--- a/redis/redis-console/src/test/java/com/ctrip/xpipe/redis/console/service/impl/KeepercontainerServiceImplTest.java
+++ b/redis/redis-console/src/test/java/com/ctrip/xpipe/redis/console/service/impl/KeepercontainerServiceImplTest.java
@@ -35,6 +35,18 @@ public class KeepercontainerServiceImplTest extends AbstractServiceImplTest{
 
     }
 
+    @Test
+    public void testFindKeeperCountByCluster() {
+        long orgId = 2L;
+        List<KeepercontainerTbl> keeperCount = keepercontainerService.findKeeperCountByClusterOrg(dcNames[0], orgId);
+        keeperCount.forEach(kc -> logger.info("{}", kc));
+        Assert.assertTrue(keeperCount.stream().allMatch(kc->kc.getKeepercontainerOrgId() == orgId));
+        logger.info("------------------------------------------------------------------");
+        long noneOrgId = 0L;
+        keeperCount = keepercontainerService.findKeeperCountByClusterOrg(dcNames[0], noneOrgId);
+        keeperCount.forEach(kc -> logger.info("{}", kc));
+        Assert.assertTrue(keeperCount.stream().allMatch(kc->kc.getKeepercontainerOrgId() == noneOrgId));
+    }
 
     @Test
     public  void testFindAllActiveByDcName(){

--- a/redis/redis-console/src/test/java/com/ctrip/xpipe/redis/console/service/impl/RedisServiceImplTest.java
+++ b/redis/redis-console/src/test/java/com/ctrip/xpipe/redis/console/service/impl/RedisServiceImplTest.java
@@ -78,7 +78,7 @@ public class RedisServiceImplTest extends AbstractServiceImplTest {
 
         redisService.deleteKeepers(dcName, clusterName, shardName);
 
-        List<KeeperBasicInfo> newKeepers = keeperAdvancedService.findBestKeepers(dcName);
+        List<KeeperBasicInfo> newKeepers = keeperAdvancedService.findBestKeepers(dcName, clusterName);
 
         Assert.assertEquals(2, newKeepers.size());
 

--- a/redis/redis-console/src/test/resources/apptest.sql
+++ b/redis/redis-console/src/test/resources/apptest.sql
@@ -44,3 +44,22 @@ insert into DC_CLUSTER_SHARD_TBL (dc_cluster_shard_id,dc_cluster_id,shard_id,set
 insert into DC_CLUSTER_SHARD_TBL (dc_cluster_shard_id,dc_cluster_id,shard_id,setinel_id,dc_cluster_shard_phase) values (6,4,3,2,1);
 insert into DC_CLUSTER_SHARD_TBL (dc_cluster_shard_id,dc_cluster_id,shard_id,setinel_id,dc_cluster_shard_phase) values (7,3,4,1,1);
 insert into DC_CLUSTER_SHARD_TBL (dc_cluster_shard_id,dc_cluster_id,shard_id,setinel_id,dc_cluster_shard_phase) values (8,4,4,2,1);
+
+insert into KEEPERCONTAINER_TBL(keepercontainer_id,keepercontainer_dc,keepercontainer_ip,keepercontainer_port,keepercontainer_active, keepercontainer_org_id) values (7,1,'127.0.0.2',7083,1,2);
+insert into KEEPERCONTAINER_TBL(keepercontainer_id,keepercontainer_dc,keepercontainer_ip,keepercontainer_port,keepercontainer_active, keepercontainer_org_id) values (8,1,'127.0.0.2',7084,1,2);
+insert into KEEPERCONTAINER_TBL(keepercontainer_id,keepercontainer_dc,keepercontainer_ip,keepercontainer_port,keepercontainer_active, keepercontainer_org_id) values (9,2,'127.0.0.2',7083,1,2);
+insert into KEEPERCONTAINER_TBL(keepercontainer_id,keepercontainer_dc,keepercontainer_ip,keepercontainer_port,keepercontainer_active, keepercontainer_org_id) values (10,2,'127.0.0.2',7084,1,2);
+
+
+insert into CLUSTER_TBL (id,cluster_name,activedc_id,cluster_description,cluster_last_modified_time,status,is_xpipe_interested, cluster_org_id) values (3,'cluster3',2,'Cluster:cluster3 , ActiveDC : B','0000000000000000','Normal',1, 3);
+
+insert into DC_CLUSTER_TBL (dc_cluster_id,dc_id,cluster_id,dc_cluster_phase,metaserver_id) values (5,1,3,1,0);
+insert into DC_CLUSTER_TBL (dc_cluster_id,dc_id,cluster_id,dc_cluster_phase,metaserver_id) values (6,2,3,1,0);
+
+insert into SHARD_TBL (id,shard_name,setinel_monitor_name,cluster_id) values(5,'cluster3shard1','cluster3shard1', 3);
+insert into SHARD_TBL (id,shard_name,setinel_monitor_name,cluster_id) values(6,'cluster3shard2','cluster3shard2', 3);
+
+insert into DC_CLUSTER_SHARD_TBL (dc_cluster_shard_id,dc_cluster_id,shard_id,setinel_id,dc_cluster_shard_phase) values (9, 5,5,1,1);
+insert into DC_CLUSTER_SHARD_TBL (dc_cluster_shard_id,dc_cluster_id,shard_id,setinel_id,dc_cluster_shard_phase) values (10,6,5,2,1);
+insert into DC_CLUSTER_SHARD_TBL (dc_cluster_shard_id,dc_cluster_id,shard_id,setinel_id,dc_cluster_shard_phase) values (11,5,6,1,1);
+insert into DC_CLUSTER_SHARD_TBL (dc_cluster_shard_id,dc_cluster_id,shard_id,setinel_id,dc_cluster_shard_phase) values (12,6,6,2,1);

--- a/redis/redis-console/src/test/resources/apptest.sql
+++ b/redis/redis-console/src/test/resources/apptest.sql
@@ -30,3 +30,17 @@ insert into REDIS_TBL (id,run_id,dc_cluster_shard_id,redis_ip,redis_port,redis_r
 insert into REDIS_TBL (id,run_id,dc_cluster_shard_id,redis_ip,redis_port,redis_role,master,redis_master,keepercontainer_id) values(16,'beeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',4,'127.0.0.1',7101,'keeper',0,-1,5);
 insert into REDIS_TBL (id,run_id,dc_cluster_shard_id,redis_ip,redis_port,redis_role,master,redis_master,keepercontainer_id) values(17,'unknown',4,'127.0.0.1',7579,'redis',0,-1,null);
 insert into REDIS_TBL (id,run_id,dc_cluster_shard_id,redis_ip,redis_port,redis_role,master,redis_master,keepercontainer_id) values(18,'unknown',4,'127.0.0.1',7679,'redis',0,-1,null);
+
+
+insert into CLUSTER_TBL (id,cluster_name,activedc_id,cluster_description,cluster_last_modified_time,status,is_xpipe_interested, cluster_org_id) values (2,'cluster2',1,'Cluster:cluster2 , ActiveDC : A','0000000000000000','Normal',1, 2);
+
+insert into DC_CLUSTER_TBL (dc_cluster_id,dc_id,cluster_id,dc_cluster_phase,metaserver_id) values (3,1,2,1,0);
+insert into DC_CLUSTER_TBL (dc_cluster_id,dc_id,cluster_id,dc_cluster_phase,metaserver_id) values (4,2,2,1,0);
+
+insert into SHARD_TBL (id,shard_name,setinel_monitor_name,cluster_id) values(3,'cluster2shard1','cluster2shard1', 2);
+insert into SHARD_TBL (id,shard_name,setinel_monitor_name,cluster_id) values(4,'cluster2shard2','cluster2shard2', 2);
+
+insert into DC_CLUSTER_SHARD_TBL (dc_cluster_shard_id,dc_cluster_id,shard_id,setinel_id,dc_cluster_shard_phase) values (5,3,3,1,1);
+insert into DC_CLUSTER_SHARD_TBL (dc_cluster_shard_id,dc_cluster_id,shard_id,setinel_id,dc_cluster_shard_phase) values (6,4,3,2,1);
+insert into DC_CLUSTER_SHARD_TBL (dc_cluster_shard_id,dc_cluster_id,shard_id,setinel_id,dc_cluster_shard_phase) values (7,3,4,1,1);
+insert into DC_CLUSTER_SHARD_TBL (dc_cluster_shard_id,dc_cluster_id,shard_id,setinel_id,dc_cluster_shard_phase) values (8,4,4,2,1);


### PR DESCRIPTION
## 改动了DB的表结构，增加了

1. organization_tbl表
2. 在cluster_tbl中，增加了cluster_admin_emails，cluster_org_id
3. 在keepercontainer_tbl中，增加了keepercontainer_org_id

## 改动了原有REST-API，增加了cluster name变量，来控制keepercontainer的总集合

