### PR TITLE
refactor endpoint health check

### DIFF
--- a/core/src/main/java/com/ctrip/xpipe/netty/commands/AbstractNettyRequestResponseCommand.java
+++ b/core/src/main/java/com/ctrip/xpipe/netty/commands/AbstractNettyRequestResponseCommand.java
@@ -59,7 +59,7 @@ public abstract class AbstractNettyRequestResponseCommand<V> extends AbstractNet
 				
 				@Override
 				public void doRun() {
-					logger.info("[run][timeout]{}", nettyClient);
+					logger.info("[{}][run][timeout]{}", AbstractNettyRequestResponseCommand.this.getClass().getSimpleName(), nettyClient);
 					future().setFailure(new CommandTimeoutException("timeout " +  + getCommandTimeoutMilli()));
 				}
 			}, getCommandTimeoutMilli(), TimeUnit.MILLISECONDS);

--- a/redis/redis-core/src/main/java/com/ctrip/xpipe/redis/core/proxy/endpoint/DefaultEndpointHealthChecker.java
+++ b/redis/redis-core/src/main/java/com/ctrip/xpipe/redis/core/proxy/endpoint/DefaultEndpointHealthChecker.java
@@ -1,14 +1,23 @@
 package com.ctrip.xpipe.redis.core.proxy.endpoint;
 
 import com.ctrip.xpipe.api.command.CommandFuture;
+import com.ctrip.xpipe.api.command.CommandFutureListener;
 import com.ctrip.xpipe.api.endpoint.Endpoint;
+import com.ctrip.xpipe.concurrent.AbstractExceptionLogTask;
 import com.ctrip.xpipe.netty.TcpPortCheckCommand;
+import com.ctrip.xpipe.utils.DateTimeUtils;
+import com.ctrip.xpipe.utils.TcpPortCheck;
+import com.ctrip.xpipe.utils.VisibleForTesting;
+import com.google.common.collect.Maps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * @author chen.zhu
@@ -17,19 +26,186 @@ import java.util.concurrent.TimeoutException;
  */
 public class DefaultEndpointHealthChecker implements EndpointHealthChecker {
 
-    private static final int TIMEOUT_MILLI = 1000 * 5;
+    protected static long DEFAULT_DROP_ENDPOINT_INTERVAL_MILLI = Long.parseLong(System.getProperty("endpoint.health.check.drop.interval", "600000"));
+
+    private static final int ENDPOINT_HEALTH_CHECK_INTERVAL = Integer.parseInt(System.getProperty("endpoint.health.check.interval", "1000"));
 
     private static final Logger logger = LoggerFactory.getLogger(DefaultEndpointHealthChecker.class);
 
+    private ScheduledExecutorService scheduled;
+
+    private Map<Endpoint, EndpointHealthStatus> allHealthStatus = Maps.newConcurrentMap();
+
+    public DefaultEndpointHealthChecker(ScheduledExecutorService scheduled) {
+        this.scheduled = scheduled;
+    }
+
     @Override
     public boolean checkConnectivity(Endpoint endpoint) {
-        CommandFuture<Boolean> future = new TcpPortCheckCommand(endpoint.getHost(), endpoint.getPort()).execute();
-
         try {
-            return future.get(TIMEOUT_MILLI, TimeUnit.MILLISECONDS);
-        } catch (InterruptedException | ExecutionException | TimeoutException e) {
-            logger.error("[checkConnectivity] ", e);
+            if(!allHealthStatus.containsKey(endpoint)) {
+                allHealthStatus.put(endpoint, new EndpointHealthStatus(endpoint));
+            }
+            return allHealthStatus.get(endpoint).isHealthy();
+        } catch (Exception e) {
+            logger.error("[checkConnectivity]", e);
         }
         return false;
+    }
+
+    @VisibleForTesting
+    protected Map<Endpoint, EndpointHealthStatus> getAllHealthStatus() {
+        return allHealthStatus;
+    }
+
+    @VisibleForTesting
+    protected class EndpointHealthStatus {
+
+        private AtomicReference<EndpointHealthState> healthState = new AtomicReference<>(EndpointHealthState.UNKNOWN);
+
+        private volatile boolean isHealthy = true;
+
+        private volatile long lastHealthyTimeMilli = System.currentTimeMillis();
+
+        private Endpoint endpoint;
+
+        private EndpointHealthStatus(Endpoint endpoint) {
+            this.endpoint = endpoint;
+            scheduledHealthCheck();
+        }
+
+        public boolean isHealthy() {
+            return isHealthy;
+        }
+
+        public EndpointHealthState getHealthState() {
+            return healthState.get();
+        }
+
+        private synchronized void setHealthState(EndpointHealthState state) {
+            healthState.set(state);
+            if(EndpointHealthState.HEALTHY.equals(state)) {
+                lastHealthyTimeMilli = System.currentTimeMillis();
+                isHealthy = true;
+            } else if(EndpointHealthState.UNHEALTHY.equals(state)) {
+                isHealthy = false;
+                checkIfNeedRemove();
+            }
+        }
+
+        private void scheduledHealthCheck() {
+            scheduled.scheduleWithFixedDelay(new AbstractExceptionLogTask() {
+                @Override
+                protected void doRun() {
+                    check();
+                }
+            }, ENDPOINT_HEALTH_CHECK_INTERVAL, ENDPOINT_HEALTH_CHECK_INTERVAL, TimeUnit.MILLISECONDS);
+        }
+
+        private void check() {
+            TcpPortCheckCommand command = new TcpPortCheckCommand(endpoint.getHost(), endpoint.getPort());
+            command.execute().addListener(new CommandFutureListener<Boolean>() {
+                @Override
+                public void operationComplete(CommandFuture<Boolean> future) throws Exception {
+                    if(future.isSuccess() && future.get()) {
+                        setHealthState(healthState.get().afterSuccess());
+                        return;
+                    }
+                    setHealthState(healthState.get().afterFail());
+                }
+            });
+        }
+
+        private void checkIfNeedRemove() {
+            long currentTime = System.currentTimeMillis();
+            if(currentTime - lastHealthyTimeMilli >= DEFAULT_DROP_ENDPOINT_INTERVAL_MILLI) {
+                logger.warn("[checkIfNeedRemove][over 10 min] remove health check for endpoint, {}", endpoint);
+                allHealthStatus.remove(endpoint);
+            }
+        }
+
+        @Override
+        public String toString() {
+            return "EndpointHealthStatus{" +
+                    "healthState=" + healthState +
+                    ", isHealthy=" + isHealthy +
+                    ", lastHealthyTimeMilli=" + DateTimeUtils.timeAsString(lastHealthyTimeMilli) +
+                    ", endpoint=" + endpoint +
+                    '}';
+        }
+    }
+
+    enum EndpointHealthState {
+
+        UNKNOWN{
+            @Override
+            protected EndpointHealthState afterSuccess() {
+                return HEALTHY;
+            }
+
+            @Override
+            protected EndpointHealthState afterFail() {
+                return FAIL_ONCE;
+            }
+        }, SUCCESS_ONCE {
+
+            @Override
+            protected EndpointHealthState afterSuccess() {
+                return HEALTHY;
+            }
+
+            @Override
+            protected EndpointHealthState afterFail() {
+                return FAIL_ONCE;
+            }
+        }, HEALTHY {
+
+            @Override
+            protected EndpointHealthState afterSuccess() {
+                return HEALTHY;
+            }
+
+            @Override
+            protected EndpointHealthState afterFail() {
+                return FAIL_ONCE;
+            }
+        }, FAIL_ONCE {
+
+            @Override
+            protected EndpointHealthState afterSuccess() {
+                return HEALTHY;
+            }
+
+            @Override
+            protected EndpointHealthState afterFail() {
+                return FAIL_TWICE;
+            }
+        }, FAIL_TWICE {
+
+            @Override
+            protected EndpointHealthState afterSuccess() {
+                return SUCCESS_ONCE;
+            }
+
+            @Override
+            protected EndpointHealthState afterFail() {
+                return UNHEALTHY;
+            }
+        }, UNHEALTHY {
+
+            @Override
+            protected EndpointHealthState afterSuccess() {
+                return SUCCESS_ONCE;
+            }
+
+            @Override
+            protected EndpointHealthState afterFail() {
+                return UNHEALTHY;
+            }
+        };
+
+        protected abstract EndpointHealthState afterSuccess();
+
+        protected abstract EndpointHealthState afterFail();
     }
 }

--- a/redis/redis-core/src/main/java/com/ctrip/xpipe/redis/core/proxy/endpoint/DefaultProxyEndpointManager.java
+++ b/redis/redis-core/src/main/java/com/ctrip/xpipe/redis/core/proxy/endpoint/DefaultProxyEndpointManager.java
@@ -33,7 +33,7 @@ public class DefaultProxyEndpointManager implements ProxyEndpointManager {
 
     private Set<ProxyEndpoint> availableEndpoints = Sets.newConcurrentHashSet();
 
-    private EndpointHealthChecker healthChecker = new DefaultEndpointHealthChecker();
+    private EndpointHealthChecker healthChecker;
 
     private Future future;
 
@@ -46,6 +46,7 @@ public class DefaultProxyEndpointManager implements ProxyEndpointManager {
         this.scheduled = MoreExecutors.getExitingScheduledExecutorService(
                 new ScheduledThreadPoolExecutor(1, XpipeThreadFactory.create("ProxyEndpointManager")),
                 THREAD_POOL_TIME_OUT, TimeUnit.SECONDS);
+        this.healthChecker = new DefaultEndpointHealthChecker(scheduled);
         start();
     }
 
@@ -91,12 +92,9 @@ public class DefaultProxyEndpointManager implements ProxyEndpointManager {
         @Override
         protected void doRun() throws Exception {
             for(ProxyEndpoint endpoint : allEndpoints) {
-                DefaultProxyEndpointManager.logger.debug("[HealthCheckTask] checking endpoint: {}", endpoint.getUri());
                 if(healthChecker.checkConnectivity(endpoint)) {
-                    DefaultProxyEndpointManager.logger.debug("[HealthCheckTask] endpoint ok: {}", endpoint.getUri());
                     availableEndpoints.add(endpoint);
                 } else {
-                    DefaultProxyEndpointManager.logger.warn("[HealthCheckTask] endpoint not healthy: {}", endpoint.getUri());
                     availableEndpoints.remove(endpoint);
                 }
             }

--- a/redis/redis-core/src/test/java/com/ctrip/xpipe/redis/core/proxy/endpoint/DefaultEndpointHealthCheckerTest.java
+++ b/redis/redis-core/src/test/java/com/ctrip/xpipe/redis/core/proxy/endpoint/DefaultEndpointHealthCheckerTest.java
@@ -1,0 +1,98 @@
+package com.ctrip.xpipe.redis.core.proxy.endpoint;
+
+import com.ctrip.xpipe.api.endpoint.Endpoint;
+import com.ctrip.xpipe.redis.core.AbstractRedisTest;
+import com.ctrip.xpipe.simpleserver.Server;
+import org.junit.*;
+
+/**
+ * @author chen.zhu
+ * <p>
+ * Oct 15, 2018
+ */
+public class DefaultEndpointHealthCheckerTest extends AbstractRedisTest {
+
+    private DefaultEndpointHealthChecker checker;
+
+    private Server server;
+
+    private Endpoint endpoint;
+
+    @Before
+    public void beforeDefaultEndpointHealthCheckerTest() throws Exception {
+        checker = new DefaultEndpointHealthChecker(scheduled);
+        server = startEmptyServer();
+        endpoint = localhostEndpoint(server.getPort());
+        DefaultEndpointHealthChecker.DEFAULT_DROP_ENDPOINT_INTERVAL_MILLI = 1000 * 10;
+    }
+
+    @After
+    public void afterDefaultEndpointHealthCheckerTest() throws Exception {
+        if(server != null && server.getLifecycleState().canStop()) {
+            server.stop();
+        }
+    }
+
+    @Test
+    public void testCheckConnectivity() {
+        boolean status = checker.checkConnectivity(endpoint);
+        Assert.assertTrue(status);
+        Assert.assertTrue(checker.getAllHealthStatus().containsKey(endpoint));
+    }
+
+    @Ignore
+    @Test
+    public void testCheckConnectivityWithSeveralTimeLater() {
+        boolean status = checker.checkConnectivity(endpoint);
+        Assert.assertTrue(status);
+        Assert.assertTrue(checker.getAllHealthStatus().containsKey(endpoint));
+        sleep(10 * 1000);
+        Assert.assertTrue(checker.checkConnectivity(endpoint));
+        logger.info("{}", checker.getAllHealthStatus().get(endpoint));
+    }
+
+    @Ignore
+    @Test
+    public void testOverTime() throws Exception {
+        checker.checkConnectivity(endpoint);
+        sleep(1000);
+        Assert.assertTrue(checker.checkConnectivity(endpoint));
+        Assert.assertTrue(checker.getAllHealthStatus().containsKey(endpoint));
+
+        server.stop();
+        sleep(1000 * 10);
+        Assert.assertFalse(checker.getAllHealthStatus().containsKey(endpoint));
+
+    }
+
+
+    @Ignore
+    @Test
+    public void testHealthStateChange() throws Exception {
+        checker.checkConnectivity(endpoint);
+        DefaultEndpointHealthChecker.EndpointHealthState state = checker.getAllHealthStatus().get(endpoint).getHealthState();
+        Assert.assertEquals(DefaultEndpointHealthChecker.EndpointHealthState.UNKNOWN, state);
+
+        sleep(2000);
+        state = checker.getAllHealthStatus().get(endpoint).getHealthState();
+        Assert.assertEquals(DefaultEndpointHealthChecker.EndpointHealthState.HEALTHY, state);
+        Assert.assertTrue(checker.checkConnectivity(endpoint));
+
+        server.stop();
+        sleep(1000);
+        state = checker.getAllHealthStatus().get(endpoint).getHealthState();
+        Assert.assertEquals(DefaultEndpointHealthChecker.EndpointHealthState.FAIL_ONCE, state);
+        Assert.assertTrue(checker.checkConnectivity(endpoint));
+
+
+        sleep(1000);
+        state = checker.getAllHealthStatus().get(endpoint).getHealthState();
+        Assert.assertEquals(DefaultEndpointHealthChecker.EndpointHealthState.FAIL_TWICE, state);
+        Assert.assertTrue(checker.checkConnectivity(endpoint));
+
+        sleep(1100);
+        state = checker.getAllHealthStatus().get(endpoint).getHealthState();
+        Assert.assertEquals(DefaultEndpointHealthChecker.EndpointHealthState.UNHEALTHY, state);
+        Assert.assertFalse(checker.checkConnectivity(endpoint));
+    }
+}

--- a/redis/redis-core/src/test/java/com/ctrip/xpipe/redis/core/proxy/endpoint/DefaultEndpointHealthCheckerTest.java
+++ b/redis/redis-core/src/test/java/com/ctrip/xpipe/redis/core/proxy/endpoint/DefaultEndpointHealthCheckerTest.java
@@ -73,10 +73,11 @@ public class DefaultEndpointHealthCheckerTest extends AbstractRedisTest {
         DefaultEndpointHealthChecker.EndpointHealthState state = checker.getAllHealthStatus().get(endpoint).getHealthState();
         Assert.assertEquals(DefaultEndpointHealthChecker.EndpointHealthState.UNKNOWN, state);
 
-        sleep(2000);
+        sleep(10 * 2000);
         state = checker.getAllHealthStatus().get(endpoint).getHealthState();
         Assert.assertEquals(DefaultEndpointHealthChecker.EndpointHealthState.HEALTHY, state);
         Assert.assertTrue(checker.checkConnectivity(endpoint));
+        logger.info("[jump out of]");
 
         server.stop();
         sleep(1000);
@@ -103,6 +104,7 @@ public class DefaultEndpointHealthCheckerTest extends AbstractRedisTest {
 
         sleep(1000);
         Assert.assertTrue(checker.checkConnectivity(endpoint));
+        sleep(2000);
 
         server.stop();
         sleep(10 * 1000);

--- a/redis/redis-core/src/test/java/com/ctrip/xpipe/redis/core/proxy/endpoint/DefaultEndpointHealthCheckerTest.java
+++ b/redis/redis-core/src/test/java/com/ctrip/xpipe/redis/core/proxy/endpoint/DefaultEndpointHealthCheckerTest.java
@@ -95,4 +95,19 @@ public class DefaultEndpointHealthCheckerTest extends AbstractRedisTest {
         Assert.assertEquals(DefaultEndpointHealthChecker.EndpointHealthState.UNHEALTHY, state);
         Assert.assertFalse(checker.checkConnectivity(endpoint));
     }
+
+    @Ignore
+    @Test
+    public void testCancelPingAfterRemove() throws Exception {
+        checker.checkConnectivity(endpoint);
+
+        sleep(1000);
+        Assert.assertTrue(checker.checkConnectivity(endpoint));
+
+        server.stop();
+        sleep(10 * 1000);
+        Assert.assertFalse(checker.getAllHealthStatus().containsKey(endpoint));
+
+        sleep(10 * 1000);
+    }
 }


### PR DESCRIPTION
Refactor the designation of endpoint health check.

Current logic is as:

1. Before an endpoint health status turn into <font color=Red>**Unhealthy**</font>, three times continuously failure is expected
2. Before an endpoint health status turn into <font color=Red>**Healthy**</font>, two times continuously check success is needed
