### PR TITLE
feature complete for auto-disconnect-proxy-when-blocked

### DIFF
--- a/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/healthcheck/actions/interaction/RouteHealthEventProcessor.java
+++ b/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/healthcheck/actions/interaction/RouteHealthEventProcessor.java
@@ -1,0 +1,232 @@
+package com.ctrip.xpipe.redis.console.healthcheck.actions.interaction;
+
+import com.ctrip.xpipe.api.monitor.EventMonitor;
+import com.ctrip.xpipe.endpoint.HostPort;
+import com.ctrip.xpipe.redis.console.healthcheck.RedisHealthCheckInstance;
+import com.ctrip.xpipe.redis.console.healthcheck.RedisInstanceInfo;
+import com.ctrip.xpipe.redis.console.healthcheck.actions.interaction.event.AbstractInstanceEvent;
+import com.ctrip.xpipe.redis.console.healthcheck.actions.interaction.event.InstanceSick;
+import com.ctrip.xpipe.redis.console.healthcheck.session.RedisSession;
+import com.ctrip.xpipe.redis.console.healthcheck.session.RedisSessionManager;
+import com.ctrip.xpipe.redis.console.proxy.ProxyChain;
+import com.ctrip.xpipe.redis.console.proxy.TunnelInfo;
+import com.ctrip.xpipe.redis.console.resources.MetaCache;
+import com.ctrip.xpipe.redis.console.service.ProxyService;
+import com.ctrip.xpipe.redis.console.spring.ConsoleContextConfig;
+import com.ctrip.xpipe.redis.core.protocal.cmd.InfoCommand;
+import com.ctrip.xpipe.redis.core.protocal.cmd.InfoResultExtractor;
+import com.ctrip.xpipe.spring.AbstractProfile;
+import com.ctrip.xpipe.utils.VisibleForTesting;
+import com.google.common.collect.Lists;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.Resource;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Try to disconnect proxy chain if the chain is blocked for a long time
+ * Check if the instance is through proxy connected, and if it is sick
+ *
+ * up: we don't care
+ * down: ping not response, is not about the proxy chain, is about the redis, that it's not working or networking is not working*/
+@Component
+@Profile(AbstractProfile.PROFILE_NAME_PRODUCTION)
+public class RouteHealthEventProcessor implements HealthEventProcessor {
+
+    private Logger logger = LoggerFactory.getLogger(RouteHealthEventProcessor.class);
+
+    @Autowired(required = false)
+    private MetaCache metaCache;
+
+    @Autowired
+    private RedisSessionManager redisSessionManager;
+
+    @Autowired
+    private ProxyService proxyService;
+
+    @Resource(name = ConsoleContextConfig.SCHEDULED_EXECUTOR)
+    private ScheduledExecutorService scheduled;
+
+    @Override
+    public void onEvent(AbstractInstanceEvent event) throws HealthEventProcessorException {
+        //only deal with sick instance
+        if (event instanceof InstanceSick) {
+            doOnEvent((InstanceSick) event);
+        }
+    }
+
+    @VisibleForTesting
+    protected void doOnEvent(InstanceSick instanceSick) {
+        RedisInstanceInfo instanceInfo = instanceSick.getInstance().getRedisInstanceInfo();
+        ProxyChain proxyChain = proxyService.getProxyChain(instanceInfo.getDcId(),
+                instanceInfo.getClusterId(), instanceInfo.getShardId());
+        if (proxyChain == null) {
+            return;
+        }
+        try {
+            InfoResultExtractor info = instanceSick.getInstance().getRedisSession()
+                    .syncInfo(InfoCommand.INFO_TYPE.REPLICATION);
+            if (isRedisInFullSync(info)) {
+                new FullSyncHandler(info, instanceSick.getInstance(), proxyChain).handle();
+            } else {
+                new PartialSyncHandler(info, instanceSick.getInstance(), proxyChain).handle();
+            }
+        } catch (Exception e) {
+            logger.error("[doOnEvent]", e);
+        }
+    }
+
+    @VisibleForTesting
+    protected boolean isRedisInFullSync(InfoResultExtractor info) {
+        return info.extractAsInteger("master_sync_in_progress") == 1;
+    }
+
+    private abstract class ProxyChainBlockedHandler {
+
+        protected InfoResultExtractor info;
+
+        protected RedisHealthCheckInstance instance;
+
+        protected ProxyChain proxyChain;
+
+        public ProxyChainBlockedHandler(InfoResultExtractor info, RedisHealthCheckInstance instance, ProxyChain proxyChain) {
+            this.info = info;
+            this.instance = instance;
+            this.proxyChain = proxyChain;
+        }
+
+        protected abstract void handle();
+    }
+
+    @VisibleForTesting
+    protected class FullSyncHandler extends ProxyChainBlockedHandler {
+
+        public FullSyncHandler(InfoResultExtractor info, RedisHealthCheckInstance instance, ProxyChain proxyChain) {
+            super(info, instance, proxyChain);
+        }
+
+        @Override
+        public void handle() {
+            if (bgSaveOverDue()) {
+                closeProxyChain(instance, proxyChain);
+            }
+        }
+
+        private boolean bgSaveOverDue() {
+            String clusterId = instance.getRedisInstanceInfo().getClusterId();
+            String shardId = instance.getRedisInstanceInfo().getShardId();
+            try {
+                HostPort hostPort = metaCache.findMaster(clusterId, shardId);
+                RedisSession redisSession = redisSessionManager.findOrCreateSession(hostPort);
+                InfoResultExtractor masterInfo = redisSession.syncInfo(InfoCommand.INFO_TYPE.PERSISTENCE);
+                long rdbSize = masterInfo.extractAsLong("rdb_last_cow_size");
+                long rdbExpectedRemainTime = getDelaySeconds(rdbSize)
+                        - TimeUnit.MILLISECONDS.toSeconds(instance.getHealthCheckConfig().delayDownAfterMilli());
+
+                if (rdbExpectedRemainTime > 0) {
+                    scheduled.schedule(new DelayedCloseTask(proxyChain, instance),
+                            rdbExpectedRemainTime, TimeUnit.SECONDS);
+                    return false;
+                } else {
+                    return true;
+                }
+            } catch (Exception e) {
+                logger.error("[bgSaveOverDue]", e);
+            }
+            return false;
+        }
+
+    }
+
+    @VisibleForTesting
+    protected long getDelaySeconds(long rdbSize) {
+        long base = 3 * 60; // 3 minutes / per GB size
+        long gb = 1024 * 1024 * 1024;
+        return base * (rdbSize/gb + 1);
+    }
+
+    @VisibleForTesting
+    protected class PartialSyncHandler extends ProxyChainBlockedHandler {
+
+        public PartialSyncHandler(InfoResultExtractor info, RedisHealthCheckInstance instance, ProxyChain proxyChain) {
+            super(info, instance, proxyChain);
+        }
+
+        @Override
+        public void handle() {
+            closeProxyChain(instance, proxyChain);
+        }
+    }
+
+    protected void closeProxyChain(RedisHealthCheckInstance instance, ProxyChain proxyChain) {
+        EventMonitor.DEFAULT.logEvent("XPIPE.PROXY.CHAIN", String.format("[CLOSE]%s: %s",
+                instance.getRedisInstanceInfo().getDcId(), instance.getRedisInstanceInfo().getShardId()));
+
+        List<TunnelInfo> tunnelInfos = proxyChain.getTunnels();
+        List<HostPort> backends = Lists.newArrayList();
+        for (TunnelInfo tunnelInfo : tunnelInfos) {
+            HostPort hostPort = tunnelInfo.getTunnelStatsResult().getBackend();
+            backends.add(new HostPort(tunnelInfo.getProxyModel().getHostPort().getHost(), hostPort.getPort()));
+        }
+        proxyService.deleteProxyChain(backends);
+    }
+
+    private class DelayedCloseTask implements Runnable {
+
+        private ProxyChain proxyChain;
+
+        private RedisHealthCheckInstance instance;
+
+        public DelayedCloseTask(ProxyChain proxyChain, RedisHealthCheckInstance instance) {
+            this.proxyChain = proxyChain;
+            this.instance = instance;
+        }
+
+        @Override
+        public void run() {
+            if (redisStillInFullSync()) {
+                closeProxyChain(instance, proxyChain);
+            }
+        }
+
+        private boolean redisStillInFullSync() {
+            try {
+                InfoResultExtractor info = instance.getRedisSession().syncInfo(InfoCommand.INFO_TYPE.REPLICATION);
+                return isRedisInFullSync(info);
+            } catch (Exception e) {
+                logger.error("[redisStillInFullSync]", e);
+            }
+            return false;
+        }
+    }
+
+    @VisibleForTesting
+    public RouteHealthEventProcessor setMetaCache(MetaCache metaCache) {
+        this.metaCache = metaCache;
+        return this;
+    }
+
+    @VisibleForTesting
+    public RouteHealthEventProcessor setRedisSessionManager(RedisSessionManager redisSessionManager) {
+        this.redisSessionManager = redisSessionManager;
+        return this;
+    }
+
+    @VisibleForTesting
+    public RouteHealthEventProcessor setProxyService(ProxyService proxyService) {
+        this.proxyService = proxyService;
+        return this;
+    }
+
+    @VisibleForTesting
+    public RouteHealthEventProcessor setScheduled(ScheduledExecutorService scheduled) {
+        this.scheduled = scheduled;
+        return this;
+    }
+}

--- a/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/healthcheck/session/RedisSession.java
+++ b/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/healthcheck/session/RedisSession.java
@@ -226,6 +226,13 @@ public class RedisSession {
         });
     }
 
+    public InfoResultExtractor syncInfo(InfoCommand.INFO_TYPE infoType)
+            throws InterruptedException, ExecutionException, TimeoutException {
+        InfoCommand infoCommand = new InfoCommand(clientPool, infoType, scheduled);
+        String info = infoCommand.execute().get(2000, TimeUnit.MILLISECONDS);
+        return new InfoResultExtractor(info);
+    }
+
 
     public CommandFuture<RedisInfo> getRedisReplInfo() {
         InfoReplicationCommand command = new InfoReplicationCommand(clientPool, scheduled, commandTimeOut);

--- a/redis/redis-console/src/test/java/com/ctrip/xpipe/redis/console/healthcheck/actions/interaction/RouteHealthEventProcessorTest.java
+++ b/redis/redis-console/src/test/java/com/ctrip/xpipe/redis/console/healthcheck/actions/interaction/RouteHealthEventProcessorTest.java
@@ -1,0 +1,190 @@
+package com.ctrip.xpipe.redis.console.healthcheck.actions.interaction;
+
+import com.ctrip.xpipe.AbstractTest;
+import com.ctrip.xpipe.endpoint.HostPort;
+import com.ctrip.xpipe.redis.console.controller.api.RetMessage;
+import com.ctrip.xpipe.redis.console.healthcheck.RedisHealthCheckInstance;
+import com.ctrip.xpipe.redis.console.healthcheck.actions.interaction.event.InstanceDown;
+import com.ctrip.xpipe.redis.console.healthcheck.actions.interaction.event.InstanceSick;
+import com.ctrip.xpipe.redis.console.healthcheck.actions.interaction.event.InstanceUp;
+import com.ctrip.xpipe.redis.console.healthcheck.config.HealthCheckConfig;
+import com.ctrip.xpipe.redis.console.healthcheck.impl.DefaultRedisInstanceInfo;
+import com.ctrip.xpipe.redis.console.healthcheck.session.RedisSession;
+import com.ctrip.xpipe.redis.console.healthcheck.session.RedisSessionManager;
+import com.ctrip.xpipe.redis.console.model.ProxyModel;
+import com.ctrip.xpipe.redis.console.proxy.ProxyChain;
+import com.ctrip.xpipe.redis.console.proxy.TunnelInfo;
+import com.ctrip.xpipe.redis.console.proxy.impl.DefaultProxyChain;
+import com.ctrip.xpipe.redis.console.proxy.impl.DefaultTunnelInfo;
+import com.ctrip.xpipe.redis.console.resources.MetaCache;
+import com.ctrip.xpipe.redis.console.service.ProxyService;
+import com.ctrip.xpipe.redis.core.protocal.cmd.InfoCommand;
+import com.ctrip.xpipe.redis.core.protocal.cmd.InfoResultExtractor;
+import com.ctrip.xpipe.redis.core.proxy.monitor.TunnelStatsResult;
+import com.google.common.collect.Lists;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.List;
+import java.util.concurrent.*;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class RouteHealthEventProcessorTest extends AbstractTest {
+
+    private RouteHealthEventProcessor processor = new RouteHealthEventProcessor();
+
+    @Mock
+    private MetaCache metaCache;
+
+    @Mock
+    private RedisSessionManager redisSessionManager;
+
+    @Mock
+    private ProxyService proxyService;
+
+    @Mock
+    private RedisHealthCheckInstance instance;
+
+    @Mock
+    private RedisSession redisSession;
+
+    @Mock
+    private InfoResultExtractor infoResultExtractor;
+
+    private ProxyChain proxyChain;
+
+    private ScheduledExecutorService scheduled;
+
+    @Before
+    public void beforeRouteHealthEventProcessorTest() {
+        MockitoAnnotations.initMocks(this);
+        processor.setMetaCache(metaCache).setProxyService(proxyService).setRedisSessionManager(redisSessionManager);
+        scheduled = Executors.newScheduledThreadPool(1);
+        processor.setScheduled(scheduled);
+
+        processor = spy(processor);
+
+        //decorate proxy service and proxy chain
+        when(proxyService.deleteProxyChain(anyList())).thenReturn(RetMessage.createSuccessMessage());
+
+        List<TunnelInfo> tunnels = Lists.newArrayList(
+                new DefaultTunnelInfo(new ProxyModel().setHostPort(new HostPort("127.0.0.1", 80)), "tunnel-1")
+                .setTunnelStatsResult(new TunnelStatsResult("", "", -1L, -1L, new HostPort("127.0.0.1", 443), new HostPort("127.0.0.1", 1024))),
+                new DefaultTunnelInfo(new ProxyModel().setHostPort(new HostPort("127.0.0.2", 80)), "tunnel-2")
+                .setTunnelStatsResult(new TunnelStatsResult("", "", -1L, -1L, new HostPort("127.0.0.2", 443), new HostPort("127.0.0.2", 2048)))
+        );
+        proxyChain = new DefaultProxyChain("FRA-AWS", "cluster", "shard", tunnels);
+        when(instance.getRedisInstanceInfo()).thenReturn(new DefaultRedisInstanceInfo("FRA-AWS", "cluster", "shard", new HostPort("127.0.0.3", 6379), "SHAJQ"));
+        when(instance.getRedisSession()).thenReturn(redisSession);
+        when(redisSessionManager.findOrCreateSession(any(HostPort.class))).thenReturn(redisSession);
+
+    }
+
+    @Test
+    public void testOnEventWithSickWithNoProxyChain() throws HealthEventProcessorException {
+        doNothing().when(processor).closeProxyChain(any(), any());
+        when(proxyService.getProxyChain(anyString(), anyString(), anyString())).thenReturn(null);
+
+        processor.onEvent(new InstanceSick(instance));
+
+        verify(processor, never()).closeProxyChain(any(), any());
+    }
+
+    @Test
+    public void testOnEventWithSickWithPartialSync() throws HealthEventProcessorException, InterruptedException, ExecutionException, TimeoutException {
+        doNothing().when(processor).closeProxyChain(any(), any());
+        when(proxyService.getProxyChain(anyString(), anyString(), anyString())).thenReturn(proxyChain);
+        when(redisSession.syncInfo(InfoCommand.INFO_TYPE.REPLICATION)).thenReturn(infoResultExtractor);
+        when(infoResultExtractor.extractAsInteger("master_sync_in_progress")).thenReturn(0);
+
+        processor.onEvent(new InstanceSick(instance));
+        verify(processor, times(1)).closeProxyChain(any(), any());
+    }
+
+    @Test
+    public void testOnEventWithSickWithFullSyncBlockNow() throws HealthEventProcessorException, InterruptedException, ExecutionException, TimeoutException {
+        doNothing().when(processor).closeProxyChain(any(), any());
+        when(proxyService.getProxyChain(anyString(), anyString(), anyString())).thenReturn(proxyChain);
+        when(redisSession.syncInfo(InfoCommand.INFO_TYPE.REPLICATION)).thenReturn(infoResultExtractor);
+        when(redisSession.syncInfo(InfoCommand.INFO_TYPE.PERSISTENCE)).thenReturn(infoResultExtractor);
+        when(infoResultExtractor.extractAsInteger("master_sync_in_progress")).thenReturn(1);
+        when(infoResultExtractor.extractAsLong("rdb_last_cow_size")).thenReturn(1024L);
+
+        HealthCheckConfig config = mock(HealthCheckConfig.class);
+        when(config.delayDownAfterMilli()).thenReturn((int) TimeUnit.MINUTES.toMillis(10));
+        when(instance.getHealthCheckConfig()).thenReturn(config);
+
+        when(processor.getDelaySeconds(anyLong())).thenReturn(-1L);
+        processor.onEvent(new InstanceSick(instance));
+        verify(processor, times(1)).closeProxyChain(any(), any());
+    }
+
+    @Test
+    public void testOnEventWithSickWithFullSyncBlockFuture() throws HealthEventProcessorException, InterruptedException, ExecutionException, TimeoutException {
+        doNothing().when(processor).closeProxyChain(any(), any());
+        when(proxyService.getProxyChain(anyString(), anyString(), anyString())).thenReturn(proxyChain);
+        when(redisSession.syncInfo(InfoCommand.INFO_TYPE.REPLICATION)).thenReturn(infoResultExtractor);
+        when(redisSession.syncInfo(InfoCommand.INFO_TYPE.PERSISTENCE)).thenReturn(infoResultExtractor);
+        when(infoResultExtractor.extractAsInteger("master_sync_in_progress")).thenReturn(1).thenReturn(1);
+        when(infoResultExtractor.extractAsLong("rdb_last_cow_size")).thenReturn(1024L);
+
+        HealthCheckConfig config = mock(HealthCheckConfig.class);
+        when(config.delayDownAfterMilli()).thenReturn((int) TimeUnit.SECONDS.toMillis(1));
+        when(instance.getHealthCheckConfig()).thenReturn(config);
+
+        when(processor.getDelaySeconds(anyLong())).thenReturn(2L);
+
+        processor.onEvent(new InstanceSick(instance));
+
+        Thread.sleep(1000);
+        verify(processor, atLeast(2)).isRedisInFullSync(any());
+        verify(processor, times(1)).closeProxyChain(any(), any());
+    }
+
+    @Test
+    public void testOnEventWithSickWithFullSyncNonBlock() throws HealthEventProcessorException, InterruptedException, ExecutionException, TimeoutException {
+        doNothing().when(processor).closeProxyChain(any(), any());
+        when(proxyService.getProxyChain(anyString(), anyString(), anyString())).thenReturn(proxyChain);
+        when(redisSession.syncInfo(InfoCommand.INFO_TYPE.REPLICATION)).thenReturn(infoResultExtractor);
+        when(redisSession.syncInfo(InfoCommand.INFO_TYPE.PERSISTENCE)).thenReturn(infoResultExtractor);
+        when(infoResultExtractor.extractAsInteger("master_sync_in_progress")).thenReturn(1).thenReturn(0);
+        when(infoResultExtractor.extractAsLong("rdb_last_cow_size")).thenReturn(1024L);
+
+        HealthCheckConfig config = mock(HealthCheckConfig.class);
+        when(config.delayDownAfterMilli()).thenReturn((int) TimeUnit.SECONDS.toMillis(1));
+        when(instance.getHealthCheckConfig()).thenReturn(config);
+
+        when(processor.getDelaySeconds(anyLong())).thenReturn(2L);
+
+        processor.onEvent(new InstanceSick(instance));
+
+        Thread.sleep(1000);
+        verify(processor, atLeast(2)).isRedisInFullSync(any());
+        verify(processor, never()).closeProxyChain(any(), any());
+    }
+
+    @Test
+    public void testOnEventWithUp() throws HealthEventProcessorException {
+        processor.onEvent(new InstanceUp(instance));
+        verify(processor, never()).doOnEvent(any());
+        verify(processor, never()).closeProxyChain(any(), any());
+    }
+
+    @Test
+    public void testOnEventWithDown() throws HealthEventProcessorException {
+        processor.onEvent(new InstanceDown(instance));
+        verify(processor, never()).doOnEvent(any());
+        verify(processor, never()).closeProxyChain(any(), any());
+    }
+
+    @Test
+    public void testCloseProxyChain() {
+        doCallRealMethod().when(processor).closeProxyChain(any(), any());
+        processor.closeProxyChain(instance, proxyChain);
+        verify(proxyService, times(1)).deleteProxyChain(anyList());
+    }
+}

--- a/redis/redis-core/src/main/java/com/ctrip/xpipe/redis/core/protocal/cmd/InfoCommand.java
+++ b/redis/redis-core/src/main/java/com/ctrip/xpipe/redis/core/protocal/cmd/InfoCommand.java
@@ -64,7 +64,8 @@ public class InfoCommand extends AbstractRedisCommand<String> {
 		REPLICATION,
 		SERVER,
 		SENTINEL,
-		STATS;
+		STATS,
+		PERSISTENCE;
 
 		public String cmd(){
 			return toString().toLowerCase();

--- a/redis/redis-core/src/main/java/com/ctrip/xpipe/redis/core/protocal/cmd/InfoResultExtractor.java
+++ b/redis/redis-core/src/main/java/com/ctrip/xpipe/redis/core/protocal/cmd/InfoResultExtractor.java
@@ -39,6 +39,10 @@ public class InfoResultExtractor {
         return extract(key, (value) -> value == null ? null : Integer.parseInt(value));
     }
 
+    public Long extractAsLong(String key) {
+        return extract(key, (value) -> value == null ? null : Long.parseLong(value));
+    }
+
     public Map<String, String> extract(String[] keys) {
 
         genKeyValues();


### PR DESCRIPTION
1. add a listener for redis sick event
2. only valid for redis sick and holding a proxy
3. for partially sync, disconnect the proxy chain immediately
4. for full sync, base line is 3min for 1GB data transport
    4.1 if over due, disconnect now
    4.2 otherwise, schedule a task to the future, if in future, it's still in full sync, disconnect. vice-versa
