### PR TITLE
optimize migration

### DIFF
--- a/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/controller/api/migrate/MigrationApi4Beacon.java
+++ b/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/controller/api/migrate/MigrationApi4Beacon.java
@@ -14,6 +14,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.context.request.async.DeferredResult;
 
+import java.util.concurrent.RejectedExecutionException;
+
 /**
  * @author lishanglin
  * date 2020/12/28
@@ -30,37 +32,46 @@ public class MigrationApi4Beacon {
     @PostMapping(value = "/sync")
     public DeferredResult<BeaconMigrationResponse> syncMigrate(@RequestBody BeaconMigrationRequest migrationRequest) {
         DeferredResult<BeaconMigrationResponse> response = new DeferredResult<>();
-        beaconMigrationService.migrate(migrationRequest).addListener((commandFuture) -> {
-            if (commandFuture.isSuccess()) {
-                response.setResult(BeaconMigrationResponse.success());
-                return;
-            } else if (commandFuture.isCancelled()) {
-                response.setResult(BeaconMigrationResponse.fail("timeout"));
-                return;
-            }
 
-            Throwable cause = commandFuture.cause();
-            if (cause instanceof CommandChainException) {
-                cause = cause.getCause();
-            }
+        try {
+            beaconMigrationService.migrate(migrationRequest).addListener((commandFuture) -> {
+                if (commandFuture.isSuccess()) {
+                    response.setResult(BeaconMigrationResponse.success());
+                    return;
+                } else if (commandFuture.isCancelled()) {
+                    response.setResult(BeaconMigrationResponse.fail("timeout"));
+                    return;
+                }
 
-            if (cause instanceof MigrationSystemNotHealthyException || cause instanceof ClusterNotFoundException
-                    || cause instanceof WrongClusterMetaException || cause instanceof NoAvailableDcException
-                    || cause instanceof MigrationConflictException || cause instanceof MigrationJustFinishException) {
-                logger.info("[syncMigrate][{}] fail and skip", migrationRequest.getClusterName(), cause);
-                response.setResult(BeaconMigrationResponse.skip(cause.getMessage()));
-            } else if (cause instanceof MigrationNoNeedException) {
-                logger.info("[syncMigrate][{}] no need and success", migrationRequest.getClusterName(), cause);
-                response.setResult(BeaconMigrationResponse.success());
-            } else if (cause instanceof MigrationNotSupportException || cause instanceof UnknownTargetDcException
-                    || cause instanceof  MigrationCrossZoneException) {
-                logger.warn("[syncMigrate][{}] unexpect migration", migrationRequest.getClusterName(), cause);
-                response.setResult(BeaconMigrationResponse.skip(cause.getMessage()));
-            } else {
-                logger.info("[syncMigrate][{}] fail, unknown reason", migrationRequest.getClusterName(), cause);
-                response.setResult(BeaconMigrationResponse.fail(cause.getMessage()));
-            }
-        });
+                Throwable cause = commandFuture.cause();
+                if (cause instanceof CommandChainException) {
+                    cause = cause.getCause();
+                }
+
+                if (cause instanceof MigrationSystemNotHealthyException || cause instanceof ClusterNotFoundException
+                        || cause instanceof WrongClusterMetaException || cause instanceof NoAvailableDcException
+                        || cause instanceof MigrationConflictException || cause instanceof MigrationJustFinishException) {
+                    logger.info("[syncMigrate][{}] fail and skip", migrationRequest.getClusterName(), cause);
+                    response.setResult(BeaconMigrationResponse.skip(cause.getMessage()));
+                } else if (cause instanceof MigrationNoNeedException) {
+                    logger.info("[syncMigrate][{}] no need and success", migrationRequest.getClusterName(), cause);
+                    response.setResult(BeaconMigrationResponse.success());
+                } else if (cause instanceof MigrationNotSupportException || cause instanceof UnknownTargetDcException
+                        || cause instanceof  MigrationCrossZoneException) {
+                    logger.warn("[syncMigrate][{}] unexpect migration", migrationRequest.getClusterName(), cause);
+                    response.setResult(BeaconMigrationResponse.skip(cause.getMessage()));
+                } else {
+                    logger.info("[syncMigrate][{}] fail", migrationRequest.getClusterName(), cause);
+                    response.setResult(BeaconMigrationResponse.fail(cause.getMessage()));
+                }
+            });
+        } catch (RejectedExecutionException e) {
+            logger.info("[syncMigrate] reject, skip this round", e);
+            response.setResult(BeaconMigrationResponse.skip(e.getMessage()));
+        } catch (Throwable th) {
+            logger.info("[syncMigrate] execute fail", th);
+            response.setResult(BeaconMigrationResponse.fail(th.getMessage()));
+        }
 
         return response;
     }

--- a/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/migration/MigrationResources.java
+++ b/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/migration/MigrationResources.java
@@ -43,9 +43,9 @@ public class MigrationResources {
         ThreadPoolExecutor poolExecutor = new ThreadPoolExecutor(maxPrepareThreads,
                 maxPrepareThreads,
                 120L, TimeUnit.SECONDS,
-                new ArrayBlockingQueue<>(maxPrepareThreads/2),
+                new ArrayBlockingQueue<>(maxPrepareThreads),
                 XpipeThreadFactory.create(MIGRATION_PREPARE_EXECUTOR),
-                new ThreadPoolExecutor.CallerRunsPolicy());
+                new ThreadPoolExecutor.AbortPolicy());
         poolExecutor.allowCoreThreadTimeOut(true);
         return MoreExecutors.getExitingExecutorService(
                 poolExecutor,

--- a/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/migration/MigrationResources.java
+++ b/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/migration/MigrationResources.java
@@ -18,14 +18,18 @@ public class MigrationResources {
 
     public static final String MIGRATION_EXECUTOR = "MIGRATION_EXECUTOR";
 
-    public static final int maxThreads = 512;
+    public static final String MIGRATION_PREPARE_EXECUTOR = "MIGRATION_EXECUTOR";
+
+    public static final int maxExecuteThreads = 512;
+
+    public static final int maxPrepareThreads = 256;
 
     @Bean(name = MIGRATION_EXECUTOR)
     public ExecutorService getMigrationlExecutor() {
-        ThreadPoolExecutor poolExecutor = new ThreadPoolExecutor(maxThreads,
-                maxThreads,
+        ThreadPoolExecutor poolExecutor = new ThreadPoolExecutor(maxExecuteThreads,
+                maxExecuteThreads,
                 120L, TimeUnit.SECONDS,
-                new ArrayBlockingQueue<>(maxThreads/2),
+                new ArrayBlockingQueue<>(maxExecuteThreads/2),
                 XpipeThreadFactory.create(MIGRATION_EXECUTOR),
                 new ThreadPoolExecutor.CallerRunsPolicy());
         poolExecutor.allowCoreThreadTimeOut(true);
@@ -33,4 +37,19 @@ public class MigrationResources {
                 poolExecutor,
                 AbstractSpringConfigContext.THREAD_POOL_TIME_OUT, TimeUnit.SECONDS);
     }
+
+    @Bean(name = MIGRATION_PREPARE_EXECUTOR)
+    public ExecutorService getMigrationlPrepareExecutor() {
+        ThreadPoolExecutor poolExecutor = new ThreadPoolExecutor(maxPrepareThreads,
+                maxPrepareThreads,
+                120L, TimeUnit.SECONDS,
+                new ArrayBlockingQueue<>(maxPrepareThreads/2),
+                XpipeThreadFactory.create(MIGRATION_PREPARE_EXECUTOR),
+                new ThreadPoolExecutor.CallerRunsPolicy());
+        poolExecutor.allowCoreThreadTimeOut(true);
+        return MoreExecutors.getExitingExecutorService(
+                poolExecutor,
+                AbstractSpringConfigContext.THREAD_POOL_TIME_OUT, TimeUnit.SECONDS);
+    }
+
 }

--- a/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/migration/model/impl/DefaultMigrationShard.java
+++ b/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/migration/model/impl/DefaultMigrationShard.java
@@ -21,6 +21,7 @@ import com.ctrip.xpipe.redis.core.metaserver.MetaServerConsoleService.PrimaryDcC
 import com.ctrip.xpipe.redis.core.metaserver.MetaServerConsoleService.PrimaryDcCheckMessage;
 import com.ctrip.xpipe.utils.LogUtils;
 import com.ctrip.xpipe.utils.StringUtil;
+import com.ctrip.xpipe.utils.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -357,7 +358,10 @@ public class DefaultMigrationShard extends AbstractObservable implements Migrati
 		shardMigrationResult.stepRetry(step);
 	}
 
-
+	@VisibleForTesting
+	public void setCommandBuilder(MigrationCommandBuilder builder) {
+		this.commandBuilder = builder;
+	}
 
 	public static class ShardObserverEvent{
 

--- a/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/migration/status/migration/MigrationCheckingState.java
+++ b/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/migration/status/migration/MigrationCheckingState.java
@@ -59,7 +59,7 @@ public class MigrationCheckingState extends AbstractMigrationState {
         return false;
     }
 
-    private void doShardCheck(MigrationCluster migrationCluster) {
+    protected void doShardCheck(MigrationCluster migrationCluster) {
 		List<MigrationShard> migrationShards = migrationCluster.getMigrationShards();
 		for (final MigrationShard migrationShard : migrationShards) {
 

--- a/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/service/migration/impl/BeaconMigrationServiceImpl.java
+++ b/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/service/migration/impl/BeaconMigrationServiceImpl.java
@@ -58,7 +58,7 @@ public class BeaconMigrationServiceImpl implements BeaconMigrationService {
 
     private AlertManager alertManager;
 
-    @Resource( name = MigrationResources.MIGRATION_EXECUTOR )
+    @Resource( name = MigrationResources.MIGRATION_PREPARE_EXECUTOR )
     private Executor executors;
 
     private ScheduledExecutorService scheduled;

--- a/redis/redis-console/src/test/java/com/ctrip/xpipe/redis/console/AbstractConsoleDbTest.java
+++ b/redis/redis-console/src/test/java/com/ctrip/xpipe/redis/console/AbstractConsoleDbTest.java
@@ -1,0 +1,91 @@
+package com.ctrip.xpipe.redis.console;
+
+import com.ctrip.xpipe.utils.FileUtils;
+import com.ctrip.xpipe.utils.StringUtil;
+import org.apache.commons.io.IOUtils;
+import org.apache.logging.log4j.util.Strings;
+import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
+import org.junit.After;
+import org.junit.Before;
+import org.unidal.dal.jdbc.datasource.DataSourceManager;
+import org.unidal.lookup.ContainerLoader;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+/**
+ * @author lishanglin
+ * date 2021/4/21
+ */
+public class AbstractConsoleDbTest extends AbstractConsoleTest {
+
+    public static String DATA_SOURCE = "fxxpipe";
+
+    @Before
+    public void before() throws ComponentLookupException, SQLException, IOException {
+        setUpTestDataSource();
+    }
+
+    @After
+    public void tearDown() {
+        ContainerLoader.destroy();
+    }
+
+    protected void setUpTestDataSource() throws ComponentLookupException, SQLException, IOException {
+        executeSqlScript(prepareDatas());
+    }
+
+    protected void executeSqlScript(String prepareSql) throws ComponentLookupException, SQLException {
+
+        if (StringUtil.isEmpty(prepareSql)) {
+            return;
+        }
+
+        DataSourceManager dsManager = ContainerLoader.getDefaultContainer().lookup(DataSourceManager.class);
+
+        Connection conn = null;
+        PreparedStatement stmt = null;
+        try {
+            conn = dsManager.getDataSource(DATA_SOURCE).getConnection();
+            conn.setAutoCommit(false);
+            if (!Strings.isEmpty(prepareSql)) {
+                for (String sql : prepareSql.split(";")) {
+                    String executeSql = sql.trim();
+                    if (StringUtil.isEmpty(executeSql)) continue;
+
+                    logger.debug("[setup][data]{}", executeSql);
+                    stmt = conn.prepareStatement(executeSql);
+                    stmt.executeUpdate();
+                }
+            }
+            conn.commit();
+
+        } catch (Exception ex) {
+            logger.error("[SetUpTestDataSource][fail]:", ex);
+            if (null != conn) {
+                conn.rollback();
+            }
+        } finally {
+            if (null != stmt) {
+                stmt.close();
+            }
+            if (null != conn) {
+                conn.setAutoCommit(true);
+                conn.close();
+            }
+        }
+    }
+
+    protected String prepareDatas() throws IOException {
+        return "";
+    }
+
+    public static String prepareDatasFromFile(String path) throws IOException {
+        InputStream ins = FileUtils.getFileInputStream(path);
+        return IOUtils.toString(ins);
+    }
+
+}

--- a/redis/redis-console/src/test/java/com/ctrip/xpipe/redis/console/AbstractConsoleH2DbTest.java
+++ b/redis/redis-console/src/test/java/com/ctrip/xpipe/redis/console/AbstractConsoleH2DbTest.java
@@ -29,9 +29,7 @@ import java.sql.SQLException;
  *         <p>
  *         Mar 17, 2017
  */
-public class AbstractConsoleH2DbTest extends AbstractConsoleTest {
-
-    public static String DATA_SOURCE = "fxxpipe";
+public class AbstractConsoleH2DbTest extends AbstractConsoleDbTest {
 
     public static final String TABLE_STRUCTURE = "sql/h2/xpipedemodbtables.sql";
     public static final String TABLE_DATA = "sql/h2/xpipedemodbinitdata.sql";
@@ -50,21 +48,6 @@ public class AbstractConsoleH2DbTest extends AbstractConsoleTest {
             Logger logger = LoggerFactory.getLogger("AbstractConsoleH2DbTest");
             logger.info("[setUp][dataSource location]{}", dataSourceLocation);
         }
-    }
-
-    @Before
-    public void before() throws ComponentLookupException, SQLException, IOException {
-//        ContainerLoader.getDefaultContainer().lookup(TransactionManager.class, "xpipe");
-//        ContainerLoader.getDefaultContainer().lookup(DataSourceManager.class, "xpipe");
-        setUpTestDataSource();
-    }
-
-    @After
-    public void tearDown() throws ComponentLookupException {
-//        Assert.assertFalse(ContainerLoader.getDefaultContainer().lookup(TransactionManager.class) instanceof DefaultTransactionManager);
-//        Assert.assertTrue(ContainerLoader.getDefaultContainer().lookup(TransactionManager.class) instanceof XpipeDalTransactionManager);
-//        Assert.assertTrue(ContainerLoader.getDefaultContainer().lookup(DataSourceManager.class) instanceof XPipeDataSourceManager);
-        ContainerLoader.destroy();
     }
 
     protected void setUpTestDataSource() throws ComponentLookupException, SQLException, IOException {
@@ -94,45 +77,6 @@ public class AbstractConsoleH2DbTest extends AbstractConsoleTest {
         }
     }
 
-    protected void executeSqlScript(String prepareSql) throws ComponentLookupException, SQLException {
-
-        if (StringUtil.isEmpty(prepareSql)) {
-            return;
-        }
-
-        DataSourceManager dsManager = ContainerLoader.getDefaultContainer().lookup(DataSourceManager.class);
-
-        Connection conn = null;
-        PreparedStatement stmt = null;
-        try {
-            conn = dsManager.getDataSource(DATA_SOURCE).getConnection();
-            conn.setAutoCommit(false);
-            if (!Strings.isEmpty(prepareSql)) {
-                for (String sql : prepareSql.split(";")) {
-                    logger.debug("[setup][data]{}", sql.trim());
-                    stmt = conn.prepareStatement(sql);
-                    stmt.executeUpdate();
-                }
-            }
-            conn.commit();
-
-        } catch (Exception ex) {
-            logger.error("[SetUpTestDataSource][fail]:", ex);
-            if (null != conn) {
-                conn.rollback();
-            }
-        } finally {
-            if (null != stmt) {
-                stmt.close();
-            }
-            if (null != conn) {
-                conn.setAutoCommit(true);
-                conn.close();
-            }
-        }
-    }
-
-
     protected final String KEY_H2_PORT = "h2Port";
     private Server h2Server;
 
@@ -142,16 +86,6 @@ public class AbstractConsoleH2DbTest extends AbstractConsoleTest {
         h2Server = Server.createTcpServer("-tcpPort", String.valueOf(h2Port), "-tcpAllowOthers");
         h2Server.start();
 //		new Console().runTool();
-    }
-
-
-    protected String prepareDatas() throws IOException {
-        return "";
-    }
-
-    public String prepareDatasFromFile(String path) throws IOException {
-        InputStream ins = FileUtils.getFileInputStream(path);
-        return IOUtils.toString(ins);
     }
 
 

--- a/redis/redis-console/src/test/java/com/ctrip/xpipe/redis/console/AllTests.java
+++ b/redis/redis-console/src/test/java/com/ctrip/xpipe/redis/console/AllTests.java
@@ -14,6 +14,7 @@ import com.ctrip.xpipe.redis.console.controller.api.data.meta.ClusterCreateInfoT
 import com.ctrip.xpipe.redis.console.dao.*;
 import com.ctrip.xpipe.redis.console.election.CrossDcLeaderElectionActionTest;
 import com.ctrip.xpipe.redis.console.healthcheck.NettyKeyedPoolClientFactoryTest;
+import com.ctrip.xpipe.redis.console.migration.status.migration.*;
 import com.ctrip.xpipe.redis.console.resources.DefaultPersistenceTest;
 import com.ctrip.xpipe.redis.console.service.impl.DelayServiceTest;
 import com.ctrip.xpipe.redis.console.service.impl.CrossMasterDelayServiceTest;
@@ -39,10 +40,6 @@ import com.ctrip.xpipe.redis.console.migration.model.impl.DefaultMigrationLockTe
 import com.ctrip.xpipe.redis.console.migration.model.impl.DefaultShardMigrationResultTest;
 import com.ctrip.xpipe.redis.console.migration.status.MigrationStatTest;
 import com.ctrip.xpipe.redis.console.migration.status.MigrationStatusTest;
-import com.ctrip.xpipe.redis.console.migration.status.migration.MigrationCheckingStateTest;
-import com.ctrip.xpipe.redis.console.migration.status.migration.MigrationInitiatedStateTest;
-import com.ctrip.xpipe.redis.console.migration.status.migration.MigrationPartialSuccessStateTest;
-import com.ctrip.xpipe.redis.console.migration.status.migration.MigrationPublishStatTest;
 import com.ctrip.xpipe.redis.console.migration.status.migration.statemachine.StateMachineTest;
 import com.ctrip.xpipe.redis.console.model.DcClusterShardTest;
 import com.ctrip.xpipe.redis.console.notifier.ClusterMetaModifiedNotifierTest;
@@ -87,6 +84,7 @@ import org.junit.runners.Suite.SuiteClasses;
         ClusterMetaServiceMigrationStatusChangeTest.class,
         DcServiceImplTest.class,
 
+        MigrationStateUpdateStatTest.class,
         StateMachineTest.class,
         MigrationStatusTest.class,
         ClusterMetaModifiedNotifierTest.class,

--- a/redis/redis-console/src/test/java/com/ctrip/xpipe/redis/console/migration/status/migration/MigrationStateUpdateStatTest.java
+++ b/redis/redis-console/src/test/java/com/ctrip/xpipe/redis/console/migration/status/migration/MigrationStateUpdateStatTest.java
@@ -1,0 +1,79 @@
+package com.ctrip.xpipe.redis.console.migration.status.migration;
+
+import com.ctrip.xpipe.redis.console.AbstractConsoleTest;
+import com.ctrip.xpipe.redis.console.migration.model.MigrationCluster;
+import com.ctrip.xpipe.redis.console.migration.status.MigrationState;
+import com.ctrip.xpipe.redis.console.migration.status.MigrationStatus;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+/**
+ * @author lishanglin
+ * date 2021/4/23
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class MigrationStateUpdateStatTest extends AbstractConsoleTest {
+
+    @Mock
+    private MigrationCluster holder;
+
+    @Mock
+    private MigrationState nextState;
+
+    private TestMigrationState migrationState;
+
+    @Before
+    public void setupMigrationStateUpdateStatTest() {
+        Mockito.when(holder.getMigrationExecutor()).thenReturn(executors);
+        Mockito.when(holder.getScheduled()).thenReturn(scheduled);
+        Mockito.doThrow(new RuntimeException()).when(holder).updateStat(Mockito.any());
+        migrationState = new TestMigrationState(holder, MigrationStatus.Initiated);
+    }
+
+    @Test
+    public void testContinueAfterUpdateFail() {
+        Mockito.when(nextState.getStatus()).thenReturn(MigrationStatus.Checking);
+        migrationState.getStateActionState().tryAction();
+        migrationState.updateAndProcess(nextState);
+        Mockito.verify(holder, Mockito.times(1)).process();
+    }
+
+    @Test
+    public void testStopAfterUpdateMigratingFail() throws Exception {
+        Mockito.when(nextState.getStatus()).thenReturn(MigrationStatus.Migrating);
+        migrationState.getStateActionState().tryAction();
+        migrationState.action();
+        migrationState.updateAndProcess(nextState);
+        Mockito.verify(holder, Mockito.times(1)).stop();
+    }
+
+    private static class TestMigrationState extends AbstractMigrationState {
+
+        public TestMigrationState(MigrationCluster holder, MigrationStatus status) {
+            super(holder, status);
+        }
+
+        public void updateAndProcess(MigrationState state) {
+            super.updateAndProcess(state);
+        }
+
+        @Override
+        protected void doRollback() {
+
+        }
+
+        @Override
+        protected void doAction() {
+        }
+
+        @Override
+        public void refresh() {
+
+        }
+    }
+
+}

--- a/services/ctrip-integration-test/pom.xml
+++ b/services/ctrip-integration-test/pom.xml
@@ -11,6 +11,10 @@
 
     <artifactId>ctrip-integration-test</artifactId>
 
+    <properties>
+        <testcontainers.version>1.15.3</testcontainers.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.ctrip.framework.xpipe</groupId>
@@ -103,6 +107,18 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mysql</artifactId>
+            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/services/ctrip-integration-test/pom.xml
+++ b/services/ctrip-integration-test/pom.xml
@@ -15,6 +15,16 @@
         <testcontainers.version>1.15.3</testcontainers.version>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>net.java.dev.jna</groupId>
+                <artifactId>jna</artifactId>
+                <version>5.8.0</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>com.ctrip.framework.xpipe</groupId>

--- a/services/ctrip-integration-test/src/test/java/com/ctrip/xpipe/redis/ctrip/integratedtest/console/AbstractCtripConsoleIntegrationTest.java
+++ b/services/ctrip-integration-test/src/test/java/com/ctrip/xpipe/redis/ctrip/integratedtest/console/AbstractCtripConsoleIntegrationTest.java
@@ -1,0 +1,15 @@
+package com.ctrip.xpipe.redis.ctrip.integratedtest.console;
+
+import com.ctrip.xpipe.redis.console.AbstractConsoleIntegrationTest;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author lishanglin
+ * date 2021/4/21
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = AbstractConsoleIntegrationTest.ConsoleTestConfig.class)
+public class AbstractCtripConsoleIntegrationTest extends AbstractCtripTest {
+}

--- a/services/ctrip-integration-test/src/test/java/com/ctrip/xpipe/redis/ctrip/integratedtest/console/AbstractCtripTest.java
+++ b/services/ctrip-integration-test/src/test/java/com/ctrip/xpipe/redis/ctrip/integratedtest/console/AbstractCtripTest.java
@@ -1,0 +1,116 @@
+package com.ctrip.xpipe.redis.ctrip.integratedtest.console;
+
+import com.ctrip.xpipe.redis.checker.healthcheck.HealthChecker;
+import com.ctrip.xpipe.spring.AbstractProfile;
+import com.ctrip.xpipe.utils.IOUtil;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.nio.file.FileSystemException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author lishanglin
+ * date 2021/4/21
+ */
+public class AbstractCtripTest extends AbstractMySqLTest {
+
+    public static final String CONFIG_QCONFIG_DIR_PATH = "/opt/config/100004374/qconfig/";
+    public static final String CONFIG_DAL_DIR_PATH = "/opt/config/100004374/dal/";
+
+    public static final String CONFIG_QCONFIG_APPLICATION_PATH = "/opt/config/100004374/qconfig/application.properties";
+    public static final String CONFIG_QCONFIG_DATASOURCE_PATH = "/opt/config/100004374/qconfig/datasource.properties";
+    public static final String CONFIG_QCONFIG_DATASOURCES_PATH = "/opt/config/100004374/qconfig/datasources.xml";
+    public static final String CONFIG_QCONFIG_SSO_CLIENT_PATH = "/opt/config/100004374/qconfig/sso_client_config.properties";
+    public static final String CONFIG_QCONFIG_SSO_SERVICE_PATH = "/opt/config/100004374/qconfig/sso_service_address.properties";
+    public static final String CONFIG_DAL_DATASOURCES_PATH = "/opt/config/100004374/dal/local-databases.properties";
+
+    protected static final boolean REPLACE_CONFIG = Boolean.parseBoolean(System.getProperty("xpipe.config.replace", "true"));
+
+    private static List<FileContentRegister> replacedConfigFiles;
+
+    @BeforeClass
+    public static void beforeAbstractConsoleIntegrationTest() throws Exception {
+        System.setProperty(HealthChecker.ENABLED, "false");
+        System.setProperty(AbstractProfile.PROFILE_KEY, AbstractProfile.PROFILE_NAME_TEST);
+
+        if (REPLACE_CONFIG) initLocalConfig();
+    }
+
+    @AfterClass
+    public static void afterAbstractConsoleIntegrationTest() {
+        if (REPLACE_CONFIG) recoverLocalConfig();
+    }
+
+    protected static void initConfigDir() throws Exception {
+        File qconfigDir = new File(CONFIG_QCONFIG_DIR_PATH);
+        File dalDir = new File(CONFIG_DAL_DIR_PATH);
+
+        if (!qconfigDir.exists() && !qconfigDir.mkdirs()) {
+            throw new FileSystemException(CONFIG_QCONFIG_DIR_PATH);
+        }
+        if (!dalDir.exists() && !dalDir.mkdirs()) {
+            throw new FileSystemException(CONFIG_DAL_DIR_PATH);
+        }
+    }
+
+    protected static void initLocalConfig() throws Exception {
+        initConfigDir();
+
+        replacedConfigFiles = new ArrayList<>();
+        replaceConfigContent(replacedConfigFiles, CONFIG_QCONFIG_APPLICATION_PATH, AbstractCtripTest::applicationProperties);
+        replaceConfigContent(replacedConfigFiles, CONFIG_QCONFIG_DATASOURCE_PATH, AbstractCtripTest::datasourceProperties);
+        replaceConfigContent(replacedConfigFiles, CONFIG_QCONFIG_DATASOURCES_PATH, AbstractCtripTest::datasourcesXml);
+        replaceConfigContent(replacedConfigFiles, CONFIG_QCONFIG_SSO_CLIENT_PATH, AbstractCtripTest::ssoClientProperties);
+        replaceConfigContent(replacedConfigFiles, CONFIG_QCONFIG_SSO_SERVICE_PATH, AbstractCtripTest::ssoServiceProperties);
+        replaceConfigContent(replacedConfigFiles, CONFIG_DAL_DATASOURCES_PATH, AbstractCtripTest::localDatabasesProperties);
+    }
+
+    protected static void recoverLocalConfig() {
+        recoverConfig(replacedConfigFiles);
+    }
+
+    protected static void replaceConfigContent(List<FileContentRegister> registers, String path, ConfContentSupplier contentSupplier) throws Exception {
+        File configFile = new File(path);
+        FileContentRegister register = new FileContentRegister(configFile);
+        register.loadFileContent();
+        registers.add(register);
+
+        if (!configFile.exists()) configFile.createNewFile();
+        IOUtil.copy(contentSupplier.get(), new FileOutputStream(configFile));
+    }
+
+    protected static void recoverConfig(List<FileContentRegister> registers) {
+        if (null != registers && !registers.isEmpty()) {
+            registers.forEach(FileContentRegister::restoreFileContent);
+        }
+    }
+
+    protected static String applicationProperties() throws Exception {
+        return "";
+    }
+
+    protected static String datasourceProperties() throws Exception {
+        return prepareDatasFromFile("src/test/resources/datasource.properties");
+    }
+
+    protected static String datasourcesXml() throws Exception {
+        return prepareDatasFromFile("src/test/resources/datasources.xml");
+    }
+
+    protected static String ssoClientProperties() throws Exception {
+        return "";
+    }
+
+    protected static String ssoServiceProperties() throws Exception {
+        return "";
+    }
+
+    protected static String localDatabasesProperties() throws Exception {
+        return prepareDatasFromFile("src/test/resources/local-databases.properties");
+    }
+
+}

--- a/services/ctrip-integration-test/src/test/java/com/ctrip/xpipe/redis/ctrip/integratedtest/console/AbstractMySqLTest.java
+++ b/services/ctrip-integration-test/src/test/java/com/ctrip/xpipe/redis/ctrip/integratedtest/console/AbstractMySqLTest.java
@@ -8,8 +8,6 @@ import com.github.dockerjava.api.model.Ports;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
@@ -34,8 +32,7 @@ public class AbstractMySqLTest extends AbstractConsoleDbTest {
 
     protected static final boolean USE_EMBED_MYSQL = Boolean.parseBoolean(System.getProperty("xpipe.mysql.embed", "true"));
 
-    @ClassRule
-    public static MySQLContainer mysqlContainer = (MySQLContainer) new MySQLContainer(DockerImageName.parse("mysql:5.7.23"))
+    private static MySQLContainer mysqlContainer = (MySQLContainer) new MySQLContainer(DockerImageName.parse("mysql:5.7.23"))
             .withDatabaseName(MYSQL_TEST_DATABASE)
             .withUsername(MYSQL_ROOT_USER)
             .withPassword(MYSQL_ROOT_PASSWORD)

--- a/services/ctrip-integration-test/src/test/java/com/ctrip/xpipe/redis/ctrip/integratedtest/console/AbstractMySqLTest.java
+++ b/services/ctrip-integration-test/src/test/java/com/ctrip/xpipe/redis/ctrip/integratedtest/console/AbstractMySqLTest.java
@@ -1,0 +1,71 @@
+package com.ctrip.xpipe.redis.ctrip.integratedtest.console;
+
+import com.ctrip.xpipe.redis.console.AbstractConsoleDbTest;
+import com.github.dockerjava.api.command.CreateContainerCmd;
+import com.github.dockerjava.api.model.ExposedPort;
+import com.github.dockerjava.api.model.PortBinding;
+import com.github.dockerjava.api.model.Ports;
+import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+/**
+ * @author lishanglin
+ * date 2021/4/21
+ */
+public class AbstractMySqLTest extends AbstractConsoleDbTest {
+
+    public static final String MYSQL_ROOT_USER = "root";
+    public static final String MYSQL_ROOT_PASSWORD = "123456";
+    public static final String MYSQL_TEST_DATABASE = "fxxpipedb";
+    public static final String CONTAINER_TZ = "Asia/Shanghai";
+
+    public static final String TABLE_STRUCTURE = "sql/mysql/xpipedemodbtables.sql";
+    public static final String TABLE_DATA = "sql/h2/xpipedemodbinitdata.sql";
+
+    protected static final boolean USE_EMBED_MYSQL = Boolean.parseBoolean(System.getProperty("xpipe.mysql.embed", "true"));
+
+    @ClassRule
+    public static MySQLContainer mysqlContainer = (MySQLContainer) new MySQLContainer(DockerImageName.parse("mysql:5.7.23"))
+            .withDatabaseName(MYSQL_TEST_DATABASE)
+            .withUsername(MYSQL_ROOT_USER)
+            .withPassword(MYSQL_ROOT_PASSWORD)
+            .withUrlParam("serverTimezone", CONTAINER_TZ)
+            .withEnv("TZ", CONTAINER_TZ)
+            .withEnv("MYSQL_ROOT_HOST", "%")
+            .withEnv("MYSQL_ROOT_PASSWORD", MYSQL_ROOT_PASSWORD)
+            .withCommand("mysqld --lower_case_table_names=1")
+            .withCreateContainerCmdModifier(cmd -> {
+                        ((CreateContainerCmd) cmd).getHostConfig().withPortBindings(new PortBinding(Ports.Binding.bindPort(3306), new ExposedPort(3306)));
+                    }
+            )
+            .withExposedPorts(3306).withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger("MySQL:3306")));
+
+    @BeforeClass
+    public static void setupAbstractMySqLContainerTest() throws Exception {
+        if (USE_EMBED_MYSQL) mysqlContainer.start();
+    }
+
+    @AfterClass
+    public static void afterAbstractMySqLContainerTest() {
+        if (USE_EMBED_MYSQL) mysqlContainer.close();
+    }
+
+    protected void setUpTestDataSource() throws ComponentLookupException, SQLException, IOException {
+        if (USE_EMBED_MYSQL) {
+            executeSqlScript(prepareDatasFromFile(TABLE_STRUCTURE));
+            executeSqlScript(prepareDatasFromFile(TABLE_DATA));
+            executeSqlScript(prepareDatas());
+        }
+    }
+
+}

--- a/services/ctrip-integration-test/src/test/java/com/ctrip/xpipe/redis/ctrip/integratedtest/console/AllTests.java
+++ b/services/ctrip-integration-test/src/test/java/com/ctrip/xpipe/redis/ctrip/integratedtest/console/AllTests.java
@@ -1,0 +1,19 @@
+package com.ctrip.xpipe.redis.ctrip.integratedtest.console;
+
+/**
+ * @author lishanglin
+ * date 2021/4/23
+ */
+
+import com.ctrip.xpipe.redis.ctrip.integratedtest.console.db.TransactionManagerTest;
+import com.ctrip.xpipe.redis.ctrip.integratedtest.console.migration.BeaconSyncMigrationTest;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        TransactionManagerTest.class,
+        BeaconSyncMigrationTest.class
+})
+public class AllTests {
+}

--- a/services/ctrip-integration-test/src/test/java/com/ctrip/xpipe/redis/ctrip/integratedtest/console/ConfContentSupplier.java
+++ b/services/ctrip-integration-test/src/test/java/com/ctrip/xpipe/redis/ctrip/integratedtest/console/ConfContentSupplier.java
@@ -1,0 +1,10 @@
+package com.ctrip.xpipe.redis.ctrip.integratedtest.console;
+
+/**
+ * @author lishanglin
+ * date 2021/4/21
+ */
+@FunctionalInterface
+public interface ConfContentSupplier {
+    String get() throws Exception;
+}

--- a/services/ctrip-integration-test/src/test/java/com/ctrip/xpipe/redis/ctrip/integratedtest/console/FileContentRegister.java
+++ b/services/ctrip-integration-test/src/test/java/com/ctrip/xpipe/redis/ctrip/integratedtest/console/FileContentRegister.java
@@ -1,0 +1,49 @@
+package com.ctrip.xpipe.redis.ctrip.integratedtest.console;
+
+import com.ctrip.xpipe.utils.IOUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+
+/**
+ * @author lishanglin
+ * date 2021/4/21
+ */
+public class FileContentRegister {
+
+    private File file;
+
+    private String content;
+
+    private static final Logger logger = LoggerFactory.getLogger(FileContentRegister.class);
+
+    public FileContentRegister(File file) {
+        this.file = file;
+    }
+
+    public void loadFileContent() throws Exception {
+        if (file.exists()) {
+            content = IOUtil.toString(new FileInputStream(file));
+        }
+    }
+
+    public void restoreFileContent() {
+        if (!file.exists()) {
+            return;
+        }
+
+        try {
+            if (null != content) {
+                IOUtil.copy(content, new FileOutputStream(file));
+            } else {
+                file.delete();
+            }
+        } catch (Exception e) {
+            logger.info("[storeFileContent] recover file fail {}", file.getName(), e);
+        }
+    }
+
+}

--- a/services/ctrip-integration-test/src/test/java/com/ctrip/xpipe/redis/ctrip/integratedtest/console/db/TransactionManagerTest.java
+++ b/services/ctrip-integration-test/src/test/java/com/ctrip/xpipe/redis/ctrip/integratedtest/console/db/TransactionManagerTest.java
@@ -1,14 +1,12 @@
 package com.ctrip.xpipe.redis.ctrip.integratedtest.console.db;
 
-import com.ctrip.xpipe.redis.console.AbstractConsoleIntegrationTest;
 import com.ctrip.xpipe.redis.console.dao.MigrationEventDao;
 import com.ctrip.xpipe.redis.console.migration.status.ClusterStatus;
 import com.ctrip.xpipe.redis.console.model.ClusterTbl;
 import com.ctrip.xpipe.redis.console.service.ClusterService;
 import com.ctrip.xpipe.redis.console.service.migration.impl.MigrationRequest;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
+import com.ctrip.xpipe.redis.ctrip.integratedtest.console.AbstractCtripConsoleIntegrationTest;
+import org.junit.*;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.io.IOException;
@@ -17,13 +15,13 @@ import java.io.IOException;
  * @author lishanglin
  * date 2021/4/20
  */
-public class TransactionManagerTest extends AbstractConsoleIntegrationTest {
+public class TransactionManagerTest extends AbstractCtripConsoleIntegrationTest {
 
     @Autowired
-    public MigrationEventDao migrationEventDao;
+    private MigrationEventDao migrationEventDao;
 
     @Autowired
-    public ClusterService clusterService;
+    private ClusterService clusterService;
 
     @Test
     public void testTransactionRollback() {

--- a/services/ctrip-integration-test/src/test/java/com/ctrip/xpipe/redis/ctrip/integratedtest/console/migration/mock/MockMigrationCheckingState.java
+++ b/services/ctrip-integration-test/src/test/java/com/ctrip/xpipe/redis/ctrip/integratedtest/console/migration/mock/MockMigrationCheckingState.java
@@ -1,10 +1,7 @@
 package com.ctrip.xpipe.redis.ctrip.integratedtest.console.migration.mock;
 
-import com.ctrip.xpipe.concurrent.AbstractExceptionLogTask;
 import com.ctrip.xpipe.redis.console.migration.model.MigrationCluster;
 import com.ctrip.xpipe.redis.console.migration.status.migration.MigrationCheckingState;
-
-import java.util.concurrent.TimeUnit;
 
 /**
  * @author lishanglin
@@ -14,21 +11,12 @@ public class MockMigrationCheckingState extends MigrationCheckingState {
 
     public MockMigrationCheckingState(MigrationCluster holder) {
         super(holder);
+        this.setNextAfterSuccess(new MockMigrationMigratingState(getHolder()));
     }
 
     @Override
     public void doAction() {
-        executors.execute(new AbstractExceptionLogTask() {
-            @Override
-            public void doRun() {
-                try {
-                    TimeUnit.SECONDS.sleep(3);
-                } catch (Exception e) {
-                    logger.info("[doAction] sleep fail", e);
-                }
-
-                updateAndProcess(new MockMigrationMigratingState(getHolder()));
-            }
-        });
+        MigrationCluster migrationCluster = getHolder();
+        doShardCheck(migrationCluster);
     }
 }

--- a/services/ctrip-integration-test/src/test/java/com/ctrip/xpipe/redis/ctrip/integratedtest/console/migration/mock/MockMigrationCommandBuilder.java
+++ b/services/ctrip-integration-test/src/test/java/com/ctrip/xpipe/redis/ctrip/integratedtest/console/migration/mock/MockMigrationCommandBuilder.java
@@ -1,0 +1,82 @@
+package com.ctrip.xpipe.redis.ctrip.integratedtest.console.migration.mock;
+
+import com.ctrip.xpipe.api.command.Command;
+import com.ctrip.xpipe.command.AbstractCommand;
+import com.ctrip.xpipe.endpoint.HostPort;
+import com.ctrip.xpipe.redis.console.migration.command.MigrationCommandBuilder;
+import com.ctrip.xpipe.redis.core.metaserver.MetaServerConsoleService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author lishanglin
+ * date 2021/4/22
+ */
+public class MockMigrationCommandBuilder implements MigrationCommandBuilder {
+
+    @Override
+    public Command<MetaServerConsoleService.PrimaryDcCheckMessage> buildDcCheckCommand(String cluster, String shard, String dc, String newPrimaryDc) {
+        MetaServerConsoleService.PrimaryDcCheckMessage resp = new MetaServerConsoleService.PrimaryDcCheckMessage(MetaServerConsoleService.PRIMARY_DC_CHECK_RESULT.SUCCESS);
+        return new DelayCommand<>(2000, resp);
+    }
+
+    @Override
+    public Command<MetaServerConsoleService.PreviousPrimaryDcMessage> buildPrevPrimaryDcCommand(String cluster, String shard, String prevPrimaryDc) {
+        MetaServerConsoleService.PreviousPrimaryDcMessage resp = new MetaServerConsoleService.PreviousPrimaryDcMessage(new HostPort("127.0.0.1", 6379), null, "Prev success");
+        return new DelayCommand<>(2000, resp);
+    }
+
+    @Override
+    public Command<MetaServerConsoleService.PrimaryDcChangeMessage> buildNewPrimaryDcCommand(String cluster, String shard, String newPrimaryDc, MetaServerConsoleService.PreviousPrimaryDcMessage previousPrimaryDcMessage) {
+        MetaServerConsoleService.PrimaryDcChangeMessage resp = new MetaServerConsoleService.PrimaryDcChangeMessage("New success", "127.0.0.1", 6379);
+        return new DelayCommand<>(100, resp);
+    }
+
+    @Override
+    public Command<MetaServerConsoleService.PrimaryDcChangeMessage> buildOtherDcCommand(String cluster, String shard, String primaryDc, String executeDc) {
+        MetaServerConsoleService.PrimaryDcChangeMessage resp = new MetaServerConsoleService.PrimaryDcChangeMessage(MetaServerConsoleService.PRIMARY_DC_CHANGE_RESULT.SUCCESS, "Other success");
+        return new DelayCommand<>(2000, resp);
+    }
+
+    @Override
+    public Command<MetaServerConsoleService.PreviousPrimaryDcMessage> buildRollBackCommand(String cluster, String shard, String prevPrimaryDc) {
+        return null;
+    }
+
+    private static class DelayCommand<T> extends AbstractCommand<T> {
+
+        private int delayMilli;
+
+        private T resp;
+
+        private static final Logger logger = LoggerFactory.getLogger(DelayCommand.class);
+
+        public DelayCommand(int delayMilli, T resp) {
+            this.delayMilli = delayMilli;
+            this.resp = resp;
+        }
+
+        @Override
+        protected void doExecute() throws Throwable {
+            try {
+                TimeUnit.MICROSECONDS.sleep(delayMilli);
+            } catch (Exception e) {
+                logger.info("[sleep] fail", e);
+            }
+
+            future().setSuccess(resp);
+        }
+
+        @Override
+        protected void doReset() {
+        }
+
+        @Override
+        public String getName() {
+            return "DelayCommand";
+        }
+    }
+
+}

--- a/services/ctrip-integration-test/src/test/java/com/ctrip/xpipe/redis/ctrip/integratedtest/console/migration/mock/MockMigrationCommandBuilder.java
+++ b/services/ctrip-integration-test/src/test/java/com/ctrip/xpipe/redis/ctrip/integratedtest/console/migration/mock/MockMigrationCommandBuilder.java
@@ -61,7 +61,7 @@ public class MockMigrationCommandBuilder implements MigrationCommandBuilder {
         @Override
         protected void doExecute() throws Throwable {
             try {
-                TimeUnit.MICROSECONDS.sleep(delayMilli);
+                TimeUnit.MILLISECONDS.sleep(delayMilli);
             } catch (Exception e) {
                 logger.info("[sleep] fail", e);
             }

--- a/services/ctrip-integration-test/src/test/java/com/ctrip/xpipe/redis/ctrip/integratedtest/console/migration/mock/MockMigrationInitiatedState.java
+++ b/services/ctrip-integration-test/src/test/java/com/ctrip/xpipe/redis/ctrip/integratedtest/console/migration/mock/MockMigrationInitiatedState.java
@@ -1,6 +1,7 @@
 package com.ctrip.xpipe.redis.ctrip.integratedtest.console.migration.mock;
 
 import com.ctrip.xpipe.redis.console.migration.model.MigrationCluster;
+import com.ctrip.xpipe.redis.console.migration.model.impl.DefaultMigrationShard;
 import com.ctrip.xpipe.redis.console.migration.status.migration.MigrationInitiatedState;
 
 /**
@@ -11,11 +12,18 @@ public class MockMigrationInitiatedState extends MigrationInitiatedState {
 
     public MockMigrationInitiatedState(MigrationCluster holder) {
         super(holder);
+        this.setNextAfterSuccess(new MockMigrationCheckingState(getHolder()));
     }
 
     @Override
     public void doAction() {
-        updateAndForceProcess(new MockMigrationCheckingState(getHolder()));
+        MockMigrationCommandBuilder builder = new MockMigrationCommandBuilder();
+        MigrationCluster migrationCluster = getHolder();
+        migrationCluster.getMigrationShards().forEach(migrationShard -> {
+            ((DefaultMigrationShard)migrationShard).setCommandBuilder(builder);
+        });
+
+        updateAndForceProcess(nextAfterSuccess());
     }
 
 }

--- a/services/ctrip-integration-test/src/test/java/com/ctrip/xpipe/redis/ctrip/integratedtest/console/migration/mock/MockMigrationMigratingState.java
+++ b/services/ctrip-integration-test/src/test/java/com/ctrip/xpipe/redis/ctrip/integratedtest/console/migration/mock/MockMigrationMigratingState.java
@@ -1,10 +1,7 @@
 package com.ctrip.xpipe.redis.ctrip.integratedtest.console.migration.mock;
 
-import com.ctrip.xpipe.concurrent.AbstractExceptionLogTask;
 import com.ctrip.xpipe.redis.console.migration.model.MigrationCluster;
 import com.ctrip.xpipe.redis.console.migration.status.migration.MigrationMigratingState;
-
-import java.util.concurrent.TimeUnit;
 
 /**
  * @author lishanglin
@@ -14,22 +11,12 @@ public class MockMigrationMigratingState extends MigrationMigratingState {
 
     public MockMigrationMigratingState(MigrationCluster holder) {
         super(holder);
+        this.setNextAfterSuccess(new MockMigrationPublishState(getHolder()));
     }
 
     @Override
     public void doAction() {
-        executors.execute(new AbstractExceptionLogTask() {
-            @Override
-            public void doRun() {
-                try {
-                    TimeUnit.SECONDS.sleep(3);
-                } catch (Exception e) {
-                    logger.info("[doAction] sleep fail", e);
-                }
-
-                updateAndProcess(new MockMigrationPublishState(getHolder()));
-            }
-        });
+        super.doAction();
     }
 
 }

--- a/services/ctrip-integration-test/src/test/java/com/ctrip/xpipe/redis/ctrip/integratedtest/console/migration/mock/MockMigrationPublishState.java
+++ b/services/ctrip-integration-test/src/test/java/com/ctrip/xpipe/redis/ctrip/integratedtest/console/migration/mock/MockMigrationPublishState.java
@@ -3,7 +3,6 @@ package com.ctrip.xpipe.redis.ctrip.integratedtest.console.migration.mock;
 import com.ctrip.xpipe.concurrent.AbstractExceptionLogTask;
 import com.ctrip.xpipe.redis.console.migration.model.MigrationCluster;
 import com.ctrip.xpipe.redis.console.migration.status.migration.MigrationPublishState;
-import com.ctrip.xpipe.redis.console.migration.status.migration.MigrationSuccessState;
 
 import java.util.concurrent.TimeUnit;
 
@@ -22,14 +21,14 @@ public class MockMigrationPublishState extends MigrationPublishState {
         executors.execute(new AbstractExceptionLogTask() {
             @Override
             public void doRun() {
+                getHolder().getClusterService().updateActivedcId(getHolder().getCurrentCluster().getId(), getHolder().destDcId());
                 try {
-                    getHolder().getClusterService().updateActivedcId(getHolder().getCurrentCluster().getId(), getHolder().destDcId());
-                    TimeUnit.SECONDS.sleep(2);
+                    TimeUnit.MILLISECONDS.sleep(100);
                 } catch (Exception e) {
                     logger.info("[doAction] sleep fail", e);
                 }
 
-                updateAndProcess(new MigrationSuccessState(getHolder()));
+                updateAndProcess(nextAfterSuccess());
             }
         });
     }

--- a/services/ctrip-integration-test/src/test/resources/datasource.properties
+++ b/services/ctrip-integration-test/src/test/resources/datasource.properties
@@ -1,0 +1,3 @@
+maxActive=1
+maxWait=10000
+maxIdle=1

--- a/services/ctrip-integration-test/src/test/resources/local-databases.properties
+++ b/services/ctrip-integration-test/src/test/resources/local-databases.properties
@@ -1,0 +1,3 @@
+fxxpipedb_dalcluster.dbName=fxxpipedb
+fxxpipedb_dalcluster.uid=root
+fxxpipedb_dalcluster.pwd=123456

--- a/services/ctrip-service/src/main/java/com/ctrip/xpipe/service/datasource/CtripDynamicDataSource.java
+++ b/services/ctrip-service/src/main/java/com/ctrip/xpipe/service/datasource/CtripDynamicDataSource.java
@@ -1,6 +1,8 @@
 package com.ctrip.xpipe.service.datasource;
 
 import com.ctrip.datasource.configure.DalDataSourceFactory;
+import com.ctrip.platform.dal.dao.configure.FirstAidKit;
+import com.ctrip.platform.dal.dao.configure.SerializableDataSourceConfig;
 import com.ctrip.platform.dal.dao.datasource.ClusterDynamicDataSource;
 import com.ctrip.platform.dal.dao.datasource.ForceSwitchableDataSourceAdapter;
 import com.ctrip.xpipe.service.fireman.ForceSwitchableDataSourceHolder;
@@ -8,6 +10,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.unidal.dal.jdbc.datasource.DataSource;
 import org.unidal.dal.jdbc.datasource.DataSourceDescriptor;
+import org.unidal.dal.jdbc.datasource.JdbcDataSourceDescriptor;
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -41,6 +44,12 @@ public class CtripDynamicDataSource implements DataSource {
 
     @Override
     public DataSourceDescriptor getDescriptor() {
+        FirstAidKit firstAidKit = dataSource.getFirstAidKit();
+        if (firstAidKit instanceof SerializableDataSourceConfig) {
+            ((JdbcDataSourceDescriptor)descriptor)
+                    .setProperty("url", ((SerializableDataSourceConfig) firstAidKit).getConnectionUrl());
+        }
+
         return descriptor;
     }
 

--- a/services/ctrip-service/src/main/java/com/ctrip/xpipe/service/email/CtripPlatformEmailService.java
+++ b/services/ctrip-service/src/main/java/com/ctrip/xpipe/service/email/CtripPlatformEmailService.java
@@ -41,7 +41,8 @@ public class CtripPlatformEmailService implements EmailService {
 
     private static EmailConfig config = new EmailConfig();
 
-    private static EmailServiceClient client = EmailServiceClient.getInstance(config.getEmailServiceUrl());
+    private static EmailServiceClient client = StringUtil.isEmpty(config.getEmailServiceUrl()) ?
+            EmailServiceClient.getInstance() : EmailServiceClient.getInstance(config.getEmailServiceUrl());
 
     @Override
     public void sendEmail(Email email) {


### PR DESCRIPTION
1. 拆分线程池，"切换事件构造"单独线程池，用以承接切换api调用的压力，reject策略直接报错
2. 切换事件状态更新失败时允许继续执行，除非下一状态为Migrating
3. 修复datasource打点数据
4. 一键起ctrip集成测试 - 数据库容器化