### PR TITLE
channel remote close bug

### DIFF
--- a/core/src/main/java/com/ctrip/xpipe/netty/commands/DefaultNettyClient.java
+++ b/core/src/main/java/com/ctrip/xpipe/netty/commands/DefaultNettyClient.java
@@ -3,6 +3,7 @@ package com.ctrip.xpipe.netty.commands;
 import com.ctrip.xpipe.netty.ByteBufUtils;
 import com.ctrip.xpipe.utils.ChannelUtil;
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
@@ -92,7 +93,6 @@ public class DefaultNettyClient implements NettyClient{
 		ByteBufReceiver byteBufReceiver = receivers.peek();
 
 		if(byteBufReceiver != null){
-
 			ByteBufReceiver.RECEIVER_RESULT result = byteBufReceiver.receive(channel, byteBuf);
 			switch (result){
 				case SUCCESS:
@@ -114,8 +114,14 @@ public class DefaultNettyClient implements NettyClient{
 					throw new IllegalStateException("unknown result:" + result);
 			}
 		}else{
-			logger.error("[handleResponse][no receiver][close client]{}, {}, {}", channel, byteBuf.readableBytes(), ByteBufUtils.readToString(byteBuf));
-			channel.close();
+
+			String bufStr = ByteBufUtils.readToString(byteBuf);
+			if(bufStr.length() == 2 && bufStr.equals("\r\n")) {
+				logger.error("[handleResponse][no receiver] {} : buf == '\r\n'", channel);
+			} else {
+				logger.error("[handleResponse][no receiver][close client]{}, {}, {}", channel, byteBuf.readableBytes(), bufStr);
+				channel.close();
+			}
 		}
 	}
 

--- a/core/src/test/java/com/ctrip/xpipe/netty/commands/DefaultNettyClientTest.java
+++ b/core/src/test/java/com/ctrip/xpipe/netty/commands/DefaultNettyClientTest.java
@@ -62,6 +62,12 @@ public class DefaultNettyClientTest extends AbstractTest {
     }
 
     @Test
+    public void testCommandEndCRLF() throws Exception {
+        nettyClient.handleResponse(nettyClient.channel, Unpooled.copiedBuffer("\r\n".getBytes()));
+        Assert.assertEquals(nettyClient.channel.isOpen(), true);
+    }
+
+    @Test
     public void testSendOnChannelClose() {
         String msg = "test\r\n";
         nettyClient.channel().close();

--- a/redis/redis-checker/src/test/java/com/ctrip/xpipe/redis/checker/healthcheck/actions/redisstats/backstreaming/BackStreamingActionTest.java
+++ b/redis/redis-checker/src/test/java/com/ctrip/xpipe/redis/checker/healthcheck/actions/redisstats/backstreaming/BackStreamingActionTest.java
@@ -92,7 +92,7 @@ public class BackStreamingActionTest extends AbstractCheckerTest {
             content = String.format(TMP_HIGH_VERSION_REPLICATION, onBackStreaming ? "1" : "0");
         }
 
-        return String.format("$%d\r\n%s", content.length(), content);
+        return String.format("$%d\r\n%s\r\n", content.length(), content);
     }
 
     @Test

--- a/redis/redis-checker/src/test/java/com/ctrip/xpipe/redis/checker/healthcheck/actions/redisstats/conflic/ConflictCheckActionTest.java
+++ b/redis/redis-checker/src/test/java/com/ctrip/xpipe/redis/checker/healthcheck/actions/redisstats/conflic/ConflictCheckActionTest.java
@@ -168,7 +168,7 @@ public class ConflictCheckActionTest extends AbstractCheckerTest {
         } else {
             content = String.format(TEMP_STATS_RESP, typeConflict, setConflict, delConflict, setDelConflict, modifyConflict, mergeConflict);
         }
-        return String.format("$%d\r\n%s", content.length(), content);
+        return String.format("$%d\r\n%s\r\n", content.length(), content);
     }
 
 

--- a/redis/redis-checker/src/test/java/com/ctrip/xpipe/redis/checker/healthcheck/actions/redisstats/tps/TpsCheckActionTest.java
+++ b/redis/redis-checker/src/test/java/com/ctrip/xpipe/redis/checker/healthcheck/actions/redisstats/tps/TpsCheckActionTest.java
@@ -69,7 +69,7 @@ public class TpsCheckActionTest extends AbstractCheckerTest {
 
     private String mockInfoResp() {
         String content = "instantaneous_ops_per_sec:" + redisTps + "\r\n";
-        return String.format("$%d\r\n%s", content.length(), content);
+        return String.format("$%d\r\n%s\r\n", content.length(), content);
     }
 
     @Test

--- a/redis/redis-core/src/main/java/com/ctrip/xpipe/redis/core/protocal/cmd/AbstractReplicationStorePsync.java
+++ b/redis/redis-core/src/main/java/com/ctrip/xpipe/redis/core/protocal/cmd/AbstractReplicationStorePsync.java
@@ -72,7 +72,7 @@ public abstract class AbstractReplicationStorePsync extends AbstractPsync {
 	protected BulkStringParser createRdbReader() {
 		
 		inOutPayloadReplicationStore = new InOutPayloadReplicationStore();
-		BulkStringParser rdbReader = new BulkStringParser(inOutPayloadReplicationStore);
+		BulkStringParser rdbReader = new BulkStringParser(inOutPayloadReplicationStore, null, false);
 		return rdbReader;
 	}
 

--- a/redis/redis-core/src/main/java/com/ctrip/xpipe/redis/core/protocal/cmd/InMemoryPsync.java
+++ b/redis/redis-core/src/main/java/com/ctrip/xpipe/redis/core/protocal/cmd/InMemoryPsync.java
@@ -50,7 +50,7 @@ public class InMemoryPsync extends AbstractPsync{
 
 	@Override
 	protected BulkStringParser createRdbReader() {
-		return new BulkStringParser(rdb);
+		return new BulkStringParser(rdb, null, false);
 	}
 	
 	@Override

--- a/redis/redis-core/src/main/java/com/ctrip/xpipe/redis/core/protocal/protocal/BulkStringParser.java
+++ b/redis/redis-core/src/main/java/com/ctrip/xpipe/redis/core/protocal/protocal/BulkStringParser.java
@@ -26,7 +26,7 @@ public class BulkStringParser extends AbstractRedisClientProtocol<InOutPayload> 
 	private BulkStringEofJudger eofJudger;
 	private BULK_STRING_STATE  bulkStringState = BULK_STRING_STATE.READING_EOF_MARK;
 	private BulkStringParserListener bulkStringParserListener;
-	
+	private boolean mustParseCRLF = true;
 	
 	public enum BULK_STRING_STATE{
 		READING_EOF_MARK,
@@ -37,17 +37,18 @@ public class BulkStringParser extends AbstractRedisClientProtocol<InOutPayload> 
 	}
 		
 	public BulkStringParser(String content){
-		this(new StringInOutPayload(content), null);
+		this(new StringInOutPayload(content), null, true);
 		
 	}
 	
 	public BulkStringParser(InOutPayload bulkStringPayload) {
-		this(bulkStringPayload, null);
+		this(bulkStringPayload, null , true);
 	}
 	
-	public BulkStringParser(InOutPayload bulkStringPayload, BulkStringParserListener bulkStringParserListener) {
+	public BulkStringParser(InOutPayload bulkStringPayload, BulkStringParserListener bulkStringParserListener, boolean mustParseCRLF) {
 		super(bulkStringPayload, false, false);
 		this.bulkStringParserListener = bulkStringParserListener;
+		this.mustParseCRLF = mustParseCRLF;
 	}
 
 	public void setBulkStringParserListener(BulkStringParserListener bulkStringParserListener) {
@@ -107,6 +108,9 @@ public class BulkStringParser extends AbstractRedisClientProtocol<InOutPayload> 
 				}
 			case READING_CR:
 				if (byteBuf.readableBytes() == 0) {
+					if(mustParseCRLF) {
+						return null;
+					}
 					return new BulkStringParser(payload);
 				}
 				byte data1 = byteBuf.getByte(byteBuf.readerIndex());

--- a/redis/redis-core/src/test/java/com/ctrip/xpipe/redis/core/protocal/cmd/TestAbstractRedisCommandTest.java
+++ b/redis/redis-core/src/test/java/com/ctrip/xpipe/redis/core/protocal/cmd/TestAbstractRedisCommandTest.java
@@ -83,4 +83,14 @@ public class TestAbstractRedisCommandTest extends AbstractRedisTest {
         verify(pool, times(1)).borrowObject();
     }
 
+    @Test
+    public void testCommandEndCRLF() throws Exception {
+        Server server = startServerWithFlexibleResult(new Callable<String>() {
+            @Override
+            public String call() throws Exception {
+                sleep(50);
+                return "+PONG\r\n";
+            }
+        });
+    }
 }

--- a/redis/redis-core/src/test/java/com/ctrip/xpipe/redis/core/protocal/protocal/BulkStringParserTest.java
+++ b/redis/redis-core/src/test/java/com/ctrip/xpipe/redis/core/protocal/protocal/BulkStringParserTest.java
@@ -2,6 +2,7 @@ package com.ctrip.xpipe.redis.core.protocal.protocal;
 
 import com.ctrip.xpipe.api.payload.InOutPayload;
 import com.ctrip.xpipe.payload.AbstractInOutPayload;
+import com.ctrip.xpipe.redis.core.protocal.RedisClientProtocol;
 import com.ctrip.xpipe.redis.core.protocal.protocal.AbstractBulkStringEoFJudger.BulkStringEofMarkJudger;
 import com.ctrip.xpipe.utils.StringUtil;
 import io.netty.buffer.ByteBuf;
@@ -11,6 +12,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.nio.channels.WritableByteChannel;
+import java.util.Arrays;
 
 /**
  * @author wenchao.meng
@@ -109,7 +111,51 @@ public class BulkStringParserTest extends AbstractRedisProtocolTest{
 		assertResult();
 	}
 
-	
+
+	ByteBuf createByteBuf(String data) {
+		ByteBuf byteBuf = directByteBuf(1);
+		byteBuf.writeBytes(data.getBytes());
+		return byteBuf;
+	}
+
+	@Test
+	public void testReadSomeByteBuf() {
+		String data = "$" +content.length() + "\r\n" + content + "\r\n";
+		String[] bufs = data.split("");
+		RedisClientProtocol<InOutPayload> result = null;
+		for(int i = 0; i < bufs.length; i++) {
+			Assert.assertEquals(result , null);
+			result = bs.read(createByteBuf(bufs[i]));
+		}
+		Assert.assertNotNull(result);
+	}
+
+	@Test
+	public void testCRLF() {
+		String data = "\r\n$" +content.length() + "\r\n" + content + "\r\n";
+		String[] bufs = data.split("");
+		RedisClientProtocol<InOutPayload> result = null;
+		for(int i = 0; i < bufs.length; i++) {
+			Assert.assertEquals(result , null);
+			result = bs.read(createByteBuf(bufs[i]));
+		}
+		Assert.assertNotNull(result);
+	}
+
+
+	@Test
+	public void testRdb() {
+		String data = "$" +content.length() + "\r\n" + content;
+		String[] bufs = data.split("");
+		RedisClientProtocol<InOutPayload> result = null;
+		for(int i = 0; i < bufs.length; i++) {
+			Assert.assertEquals(result , null);
+			result = bs.read(createByteBuf(bufs[i]));
+		}
+		Assert.assertNotNull(result);
+	}
+
+
 	class TestPayload  extends AbstractInOutPayload implements InOutPayload{
 
 		@Override

--- a/redis/redis-keeper/src/test/java/com/ctrip/xpipe/redis/keeper/protocal/cmd/PsyncTest.java
+++ b/redis/redis-keeper/src/test/java/com/ctrip/xpipe/redis/keeper/protocal/cmd/PsyncTest.java
@@ -162,7 +162,7 @@ public class PsyncTest extends AbstractRedisKeeperTest{
 		runData(data);
 	}
 
-	
+
 	@Test
 	public void testPsyncFullRight() throws XpipeException, IOException, InterruptedException{
 		

--- a/redis/redis-meta/src/test/java/com/ctrip/xpipe/redis/meta/server/job/PeerMasterAdjustJobTest.java
+++ b/redis/redis-meta/src/test/java/com/ctrip/xpipe/redis/meta/server/job/PeerMasterAdjustJobTest.java
@@ -191,7 +191,7 @@ public class PeerMasterAdjustJobTest extends AbstractMetaServerTest {
             index.incrementAndGet();
         });
         String content = sb.toString();
-        return String.format("$%d\r\n%s", content.length(), content);
+        return String.format("$%d\r\n%s\r\n", content.length(), content);
     }
 
     private String mockInfoServerResp() {
@@ -199,7 +199,7 @@ public class PeerMasterAdjustJobTest extends AbstractMetaServerTest {
         if (null != version) {
             content = "xredis_crdt_version:" + version;
         }
-        return String.format("$%d\r\n%s", content.length(), content);
+        return String.format("$%d\r\n%s\r\n", content.length(), content);
     }
 
     private void mockMaster() throws Exception {


### PR DESCRIPTION
When parsing redis commands, ignoring the terminator '\r\n' leads to channel close