### PR TITLE
peerof command add proxy 

### DIFF
--- a/core/src/main/java/com/ctrip/xpipe/api/endpoint/Endpoint.java
+++ b/core/src/main/java/com/ctrip/xpipe/api/endpoint/Endpoint.java
@@ -1,5 +1,7 @@
 package com.ctrip.xpipe.api.endpoint;
 
+import com.ctrip.xpipe.api.proxy.ProxyConnectProtocol;
+
 import java.net.InetSocketAddress;
 
 public interface Endpoint {
@@ -15,4 +17,6 @@ public interface Endpoint {
 	String getPassword();
 	
 	InetSocketAddress getSocketAddress();
+
+	ProxyConnectProtocol getProxyProtocol();
 }

--- a/core/src/main/java/com/ctrip/xpipe/endpoint/DefaultEndPoint.java
+++ b/core/src/main/java/com/ctrip/xpipe/endpoint/DefaultEndPoint.java
@@ -1,6 +1,8 @@
 package com.ctrip.xpipe.endpoint;
 
 import com.ctrip.xpipe.api.endpoint.Endpoint;
+import com.ctrip.xpipe.api.proxy.ProxyConnectProtocol;
+import com.ctrip.xpipe.utils.ObjectUtils;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import java.io.Serializable;
@@ -129,12 +131,15 @@ public class DefaultEndPoint implements Endpoint, Serializable{
 				return false;
 		} else if (!uri.equals(other.uri))
 			return false;
-		return true;
+		return ObjectUtils.equals(this.getProxyProtocol(), other.getProxyProtocol());
 	}
 
 	@Override
 	public InetSocketAddress getSocketAddress() {
 		return new InetSocketAddress(getHost(), getPort());
 	}
+
+	@Override
+	public ProxyConnectProtocol getProxyProtocol() { return null; }
 
 }

--- a/redis/redis-core/src/main/java/com/ctrip/xpipe/redis/core/meta/DcMetaManager.java
+++ b/redis/redis-core/src/main/java/com/ctrip/xpipe/redis/core/meta/DcMetaManager.java
@@ -20,6 +20,8 @@ public interface DcMetaManager{
 	 */
 	RouteMeta randomRoute(String clusterId);
 
+	List<RouteMeta> getAllRoutes();
+
 	/**
 	 * find all clusters in currentDc whose active dc is clusterActiveDc
 	 * @param clusterActiveDc

--- a/redis/redis-core/src/main/java/com/ctrip/xpipe/redis/core/meta/comparator/DcMetaComparator.java
+++ b/redis/redis-core/src/main/java/com/ctrip/xpipe/redis/core/meta/comparator/DcMetaComparator.java
@@ -71,6 +71,10 @@ public class DcMetaComparator extends AbstractMetaComparator<ClusterMeta, DcChan
 		for(String clusterId : intersectionClusterIds){
 			ClusterMeta currentMeta = current.findCluster(clusterId);
 			ClusterMeta futureMeta = future.findCluster(clusterId);
+			if(!currentMeta.getType().equals(futureMeta.getType())) {
+				removed.add(currentMeta);
+				added.add(futureMeta);
+			}
 			if(!reflectionEquals(currentMeta, futureMeta)){
 				ClusterMetaComparator clusterMetaComparator = new ClusterMetaComparator(currentMeta, futureMeta);
 				clusterMetaComparator.compare();

--- a/redis/redis-core/src/main/java/com/ctrip/xpipe/redis/core/meta/impl/DefaultDcMetaManager.java
+++ b/redis/redis-core/src/main/java/com/ctrip/xpipe/redis/core/meta/impl/DefaultDcMetaManager.java
@@ -130,6 +130,11 @@ public final class DefaultDcMetaManager implements DcMetaManager{
 	}
 
 	@Override
+	public List<RouteMeta> getAllRoutes() {
+		return metaManager.metaRoutes(currentDc);
+	}
+
+	@Override
 	public List<ClusterMeta> getSpecificActiveDcClusters(String clusterActiveDc) {
 
 		return metaManager.getSpecificActiveDcClusters(currentDc, clusterActiveDc);

--- a/redis/redis-core/src/main/java/com/ctrip/xpipe/redis/core/protocal/cmd/CRDTInfoResultExtractor.java
+++ b/redis/redis-core/src/main/java/com/ctrip/xpipe/redis/core/protocal/cmd/CRDTInfoResultExtractor.java
@@ -1,7 +1,15 @@
 package com.ctrip.xpipe.redis.core.protocal.cmd;
 
-import com.ctrip.xpipe.redis.core.entity.RedisMeta;
+import com.ctrip.xpipe.api.endpoint.Endpoint;
+import com.ctrip.xpipe.api.proxy.ProxyConnectProtocol;
+import com.ctrip.xpipe.endpoint.DefaultEndPoint;
+import com.ctrip.xpipe.proxy.ProxyEnabledEndpoint;
+import com.ctrip.xpipe.redis.core.proxy.PROXY_OPTION;
+import com.ctrip.xpipe.redis.core.proxy.parser.DefaultProxyConnectProtocolParser;
+import com.ctrip.xpipe.redis.core.proxy.parser.route.RouteOptionParser;
+import com.ctrip.xpipe.tuple.Pair;
 import com.ctrip.xpipe.utils.StringUtil;
+import org.apache.logging.log4j.util.Strings;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -11,17 +19,20 @@ public class CRDTInfoResultExtractor extends InfoResultExtractor {
     private static final String TEMP_PEER_HOST = "peer%d_host";
     private static final String TEMP_PEER_PORT = "peer%d_port";
     private static final String TEMP_PEER_GID = "peer%d_gid";
+    private static final String TEMP_PROXY_TYPE = "peer%d_proxy_type";
+    private static final String TEMP_PROXY_SERVERS = "peer%d_proxy_servers";
+    private static final String TEMP_PROXY_PARAMS = "peer%d_proxy_params";
 
     public CRDTInfoResultExtractor(String result) {
         super(result);
     }
 
-    public List<RedisMeta> extractPeerMasters() {
-        List<RedisMeta> peerMasters = new LinkedList<>();
+    public List<Pair<Long, Endpoint>> extractPeerMasters() {
+        List<Pair<Long, Endpoint>> peerMasters = new LinkedList<>();
 
         int index = 0;
         while (true) {
-            RedisMeta peerMaster = tryExtractPeerMaster(index);
+            Pair<Long, Endpoint> peerMaster = tryExtractPeerMaster(index);
             if (null != peerMaster) {
                 peerMasters.add(peerMaster);
             } else {
@@ -34,20 +45,32 @@ public class CRDTInfoResultExtractor extends InfoResultExtractor {
         return peerMasters;
     }
 
-    private RedisMeta tryExtractPeerMaster(int index) {
+    private Pair<Long, Endpoint> tryExtractPeerMaster(int index) {
         String host = extract(String.format(TEMP_PEER_HOST, index));
         String port = extract(String.format(TEMP_PEER_PORT, index));
         String gid = extract(String.format(TEMP_PEER_GID, index));
 
         if (null == host || null == port) return null;
-
-        RedisMeta peerMaster = new RedisMeta().setIp(host).setPort(Integer.parseInt(port));
-        if (!StringUtil.isEmpty(gid)) {
-            // allow gid missing for low version crdt redis
-            peerMaster.setGid(Long.parseLong(gid));
+        Endpoint peerEndPoint = null;
+        String proxyType = extract(String.format(TEMP_PROXY_TYPE, index));
+        if (!Strings.isEmpty(proxyType)) {
+            switch (proxyType) {
+                case PeerOfCommand.TYPE_XPIPE_PROXY:
+                    String servers = extract(String.format(TEMP_PROXY_SERVERS, index));
+                    String protocolStr = String.format("%s %s %s",ProxyConnectProtocol.KEY_WORD, PROXY_OPTION.ROUTE, servers);
+                    String params = extract(String.format(TEMP_PROXY_PARAMS, index));
+                    if(!StringUtil.isEmpty(params)) {
+                        protocolStr += " " + params;
+                    }
+                    ProxyConnectProtocol protocol = new DefaultProxyConnectProtocolParser().read(protocolStr);
+                    peerEndPoint = new ProxyEnabledEndpoint(host, Integer.parseInt(port), protocol);
+                    break;
+            }
         }
-
-        return peerMaster;
+        if (null == peerEndPoint)  {
+            peerEndPoint = new DefaultEndPoint(host, Integer.parseInt(port));
+        }
+        return new Pair<>(Long.parseLong(gid), peerEndPoint);
     }
 
 }

--- a/redis/redis-core/src/main/java/com/ctrip/xpipe/redis/core/protocal/cmd/PeerOfCommand.java
+++ b/redis/redis-core/src/main/java/com/ctrip/xpipe/redis/core/protocal/cmd/PeerOfCommand.java
@@ -1,33 +1,32 @@
 package com.ctrip.xpipe.redis.core.protocal.cmd;
 
+import com.ctrip.xpipe.api.endpoint.Endpoint;
 import com.ctrip.xpipe.api.pool.SimpleObjectPool;
+import com.ctrip.xpipe.api.proxy.ProxyConnectProtocol;
 import com.ctrip.xpipe.netty.commands.NettyClient;
 import com.ctrip.xpipe.redis.core.protocal.protocal.RequestStringParser;
-import com.ctrip.xpipe.utils.StringUtil;
+import com.ctrip.xpipe.redis.core.proxy.PROXY_OPTION;
+import com.ctrip.xpipe.redis.core.proxy.parser.route.RouteOptionParser;
 import io.netty.buffer.ByteBuf;
+import org.apache.commons.lang3.ArrayUtils;
 
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.stream.Collectors;
 
 public class PeerOfCommand extends AbstractRedisCommand {
 
     protected long gid;
-    protected String ip;
-    protected int port;
+    protected Endpoint endpoint;
 
     public PeerOfCommand(SimpleObjectPool<NettyClient> clientPool, long gid, ScheduledExecutorService scheduled) {
         super(clientPool, scheduled);
         this.gid = gid;
     }
 
-    public PeerOfCommand(SimpleObjectPool<NettyClient> clientPool, long gid, String ip, int port, ScheduledExecutorService scheduled){
-        this(clientPool, gid, ip, port, "", scheduled);
-    }
-
-    public PeerOfCommand(SimpleObjectPool<NettyClient> clientPool, long gid, String ip, int port, String param, ScheduledExecutorService scheduled) {
+    public PeerOfCommand(SimpleObjectPool<NettyClient> clientPool, long gid, Endpoint endpoint, ScheduledExecutorService scheduled) {
         super(clientPool, scheduled);
         this.gid = gid;
-        this.ip = ip;
-        this.port = port;
+        this.endpoint = endpoint;
     }
 
     @Override
@@ -35,14 +34,29 @@ public class PeerOfCommand extends AbstractRedisCommand {
         return "peerof";
     }
 
+    static final String TEMP_PROXY_TYPE = "proxy-type";
+    static final String TEMP_PROXY_SERVERS = "proxy-servers";
+    static final String TEMP_PROXY_PARAMS = "proxy-params";
+    static final String TYPE_XPIPE_PROXY = "XPIPE-PROXY";
     @Override
     public ByteBuf getRequest() {
 
-        RequestStringParser requestString = null;
-        if(StringUtil.isEmpty(ip)){
+        RequestStringParser requestString;
+        if(null == endpoint){
             requestString = new RequestStringParser(getName(), String.valueOf(gid), "no", "one");
         }else{
-            requestString = new RequestStringParser(getName(), String.valueOf(gid), ip, String.valueOf(port));
+            String[] params = ArrayUtils.addAll(null, getName(), String.valueOf(gid), endpoint.getHost(), String.valueOf(endpoint.getPort()));
+            ProxyConnectProtocol protocol = endpoint.getProxyProtocol();
+            if(protocol != null) {
+                RouteOptionParser parser = new RouteOptionParser().read(PROXY_OPTION.ROUTE + " " + protocol.getRouteInfo());
+                String servers = parser.getNextEndpoints().stream().map(endpoint-> endpoint.toString()).collect(Collectors.joining(","));
+                params = ArrayUtils.addAll(params, TEMP_PROXY_TYPE, TYPE_XPIPE_PROXY, TEMP_PROXY_SERVERS, servers);
+                String proxyParams = new RouteOptionParser().read(parser.output()).getContent();
+                if(proxyParams != null) {
+                    params = ArrayUtils.addAll(params, TEMP_PROXY_PARAMS, "\"" + proxyParams + "\"");
+                }
+            }
+            requestString = new RequestStringParser(params);
         }
         return requestString.format();
     }
@@ -52,10 +66,10 @@ public class PeerOfCommand extends AbstractRedisCommand {
 
         String target = getClientPool() == null? "null" : getClientPool().desc();
 
-        if(StringUtil.isEmpty(ip)){
+        if(null == endpoint){
             return String.format("%s: %s %d no one", target, getName(), gid);
         }else{
-            return String.format("%s: %s %d %s %d", target, getName(), gid, ip, port);
+            return String.format("%s: %s %d %s %d", target, getName(), gid, endpoint.getHost(), endpoint.getPort());
         }
     }
 

--- a/redis/redis-core/src/main/java/com/ctrip/xpipe/redis/core/proxy/protocols/DefaultProxyConnectProtocol.java
+++ b/redis/redis-core/src/main/java/com/ctrip/xpipe/redis/core/proxy/protocols/DefaultProxyConnectProtocol.java
@@ -17,6 +17,7 @@ import org.slf4j.LoggerFactory;
 
 import java.net.InetSocketAddress;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * @author chen.zhu
@@ -137,5 +138,18 @@ public class DefaultProxyConnectProtocol extends AbstractProxyProtocol<ProxyConn
     @Override
     public String toString() {
         return content;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DefaultProxyConnectProtocol that = (DefaultProxyConnectProtocol) o;
+        return Objects.equals(content, that.content);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(content);
     }
 }

--- a/redis/redis-meta/src/main/java/com/ctrip/xpipe/redis/meta/server/crdt/replication/impl/DefaultPeerMasterAdjustJobFactory.java
+++ b/redis/redis-meta/src/main/java/com/ctrip/xpipe/redis/meta/server/crdt/replication/impl/DefaultPeerMasterAdjustJobFactory.java
@@ -1,8 +1,14 @@
 package com.ctrip.xpipe.redis.meta.server.crdt.replication.impl;
 
+import com.ctrip.xpipe.api.endpoint.Endpoint;
+import com.ctrip.xpipe.api.proxy.ProxyConnectProtocol;
 import com.ctrip.xpipe.endpoint.DefaultEndPoint;
 import com.ctrip.xpipe.pool.XpipeNettyClientKeyedObjectPool;
+import com.ctrip.xpipe.proxy.ProxyEnabledEndpoint;
 import com.ctrip.xpipe.redis.core.entity.RedisMeta;
+import com.ctrip.xpipe.redis.core.entity.RouteMeta;
+import com.ctrip.xpipe.redis.core.proxy.PROXY_OPTION;
+import com.ctrip.xpipe.redis.core.proxy.parser.DefaultProxyConnectProtocolParser;
 import com.ctrip.xpipe.redis.meta.server.crdt.replication.PeerMasterAdjustJobFactory;
 import com.ctrip.xpipe.redis.meta.server.job.PeerMasterAdjustJob;
 import com.ctrip.xpipe.redis.meta.server.meta.CurrentMetaManager;
@@ -20,6 +26,7 @@ import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.stream.Collectors;
 
 import static com.ctrip.xpipe.redis.meta.server.spring.MetaServerContextConfig.CLIENT_POOL;
 import static com.ctrip.xpipe.spring.AbstractSpringConfigContext.GLOBAL_EXECUTOR;
@@ -64,8 +71,19 @@ public class DefaultPeerMasterAdjustJobFactory implements PeerMasterAdjustJobFac
             logger.info("[buildPeerMasterAdjustJob][{}][{}] unknown current master, skip adjust", clusterId, shardId);
             return null;
         }
-
-        List<RedisMeta> allPeerMasters = currentMetaManager.getAllPeerMasters(clusterId, shardId);
+        List<Pair<Long, Endpoint>> allPeerMasters = currentMetaManager.getAllPeerMasters(clusterId, shardId).entrySet().stream().map(entry -> {
+            String dcName = entry.getKey();
+            RedisMeta peerMeta = entry.getValue();
+            RouteMeta routeMeta = currentMetaManager.getClusterRouteByDcId(dcName, clusterId);
+            Endpoint endpoint;
+            if(routeMeta != null) {
+                ProxyConnectProtocol proxyProtocol =  new DefaultProxyConnectProtocolParser().read(String.format("%s %s %s", ProxyConnectProtocol.KEY_WORD, PROXY_OPTION.ROUTE, routeMeta.getRouteInfo()));
+                endpoint = new ProxyEnabledEndpoint(peerMeta.getIp(), peerMeta.getPort(), proxyProtocol);
+            } else {
+                endpoint = new DefaultEndPoint(peerMeta.getIp(), peerMeta.getPort());
+            }
+            return new Pair<>(entry.getValue().getGid(), endpoint);
+        }).collect(Collectors.toList());
         return new PeerMasterAdjustJob(clusterId, shardId, allPeerMasters,
                 Pair.of(currentMaster.getIp(), currentMaster.getPort()), false,
                 keyedObjectPool.getKeyPool(new DefaultEndPoint(currentMaster.getIp(), currentMaster.getPort())),

--- a/redis/redis-meta/src/main/java/com/ctrip/xpipe/redis/meta/server/meta/ChooseRouteStrategy.java
+++ b/redis/redis-meta/src/main/java/com/ctrip/xpipe/redis/meta/server/meta/ChooseRouteStrategy.java
@@ -1,0 +1,46 @@
+package com.ctrip.xpipe.redis.meta.server.meta;
+
+import com.ctrip.xpipe.redis.core.entity.RouteMeta;
+
+import java.util.List;
+import java.util.Random;
+
+public interface ChooseRouteStrategy {
+    RouteMeta choose(List<RouteMeta> routeMetas);
+    public static ChooseRouteStrategy RANDOM = new RandomChooseRouteStrategy();
+    static class HashCodeChooseRouteStrategy implements ChooseRouteStrategy {
+        private int hashCode;
+        public HashCodeChooseRouteStrategy(int code) {
+            this.hashCode = code;
+        }
+        @Override
+        public RouteMeta choose(List<RouteMeta> routeMetas) {
+            if(routeMetas == null || routeMetas.isEmpty()) {
+                return null;
+            }
+            return routeMetas.get(hashCode % routeMetas.size());
+        }
+
+        public void setCode(int hashCode) {
+            this.hashCode = hashCode;
+        }
+
+        public int getCode() {
+            return hashCode;
+        }
+    }
+
+    class RandomChooseRouteStrategy implements  ChooseRouteStrategy {
+        @Override
+        public RouteMeta choose(List<RouteMeta> routeMetas) {
+            if(routeMetas == null || routeMetas.isEmpty()) {
+                return null;
+            }
+            int random = new Random().nextInt(routeMetas.size());
+            return routeMetas.get(random);
+        }
+    }
+}
+
+
+

--- a/redis/redis-meta/src/main/java/com/ctrip/xpipe/redis/meta/server/meta/CurrentMeta.java
+++ b/redis/redis-meta/src/main/java/com/ctrip/xpipe/redis/meta/server/meta/CurrentMeta.java
@@ -1,6 +1,7 @@
 package com.ctrip.xpipe.redis.meta.server.meta;
 
 import com.ctrip.xpipe.api.factory.ObjectFactory;
+import com.ctrip.xpipe.api.foundation.FoundationService;
 import com.ctrip.xpipe.api.lifecycle.Releasable;
 import com.ctrip.xpipe.cluster.ClusterType;
 import com.ctrip.xpipe.codec.JsonCodec;
@@ -9,16 +10,19 @@ import com.ctrip.xpipe.redis.core.meta.MetaComparator;
 import com.ctrip.xpipe.redis.core.meta.MetaComparatorVisitor;
 import com.ctrip.xpipe.redis.core.meta.comparator.ClusterMetaComparator;
 import com.ctrip.xpipe.redis.core.meta.comparator.ShardMetaComparator;
+import com.ctrip.xpipe.redis.core.util.OrgUtil;
 import com.ctrip.xpipe.redis.meta.server.meta.impl.CurrentCRDTShardMeta;
 import com.ctrip.xpipe.redis.meta.server.meta.impl.CurrentKeeperShardMeta;
 import com.ctrip.xpipe.tuple.Pair;
 import com.ctrip.xpipe.utils.MapUtils;
+import com.ctrip.xpipe.utils.ObjectUtils;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 /**
  * @author wenchao.meng
@@ -144,6 +148,16 @@ public class CurrentMeta implements Releasable {
 		return currentCRDTShardMeta.getPeerMaster(dcId);
 	}
 
+	public RouteMeta getClusterRouteByDcId(String dcId, String clusterId) {
+		CurrentClusterMeta clusterMeta = currentMetas.get(clusterId);
+		return clusterMeta.getRouteByDcId(dcId);
+	}
+
+	public List<String> updateClusterRoutes(ClusterMeta clusterMeta, List<RouteMeta> routes) {
+		CurrentClusterMeta currentClusterMeta = currentMetas.get(clusterMeta.getId());
+		return currentClusterMeta.updateRoutes(routes, clusterMeta);
+	}
+
 	public void removePeerMaster(String dcId, String clusterId, String shardId) {
 		checkClusterSupportPeerMaster(clusterId);
 
@@ -158,7 +172,7 @@ public class CurrentMeta implements Releasable {
 		return currentCRDTShardMeta.getUpstreamPeerDcs();
 	}
 
-	public List<RedisMeta> getAllPeerMasters(String clusterId, String shardId) {
+	public Map<String, RedisMeta> getAllPeerMasters(String clusterId, String shardId) {
 		checkClusterSupportPeerMaster(clusterId);
 
 		CurrentCRDTShardMeta currentCRDTShardMeta = (CurrentCRDTShardMeta) getCurrentShardMetaOrThrowException(clusterId, shardId);
@@ -266,14 +280,17 @@ public class CurrentMeta implements Releasable {
 	}
 
 	public static class CurrentClusterMeta implements Releasable {
-
+		private static final String currentDcId = FoundationService.DEFAULT.getDataCenter();
 		@JsonIgnore
 		private static Logger logger = LoggerFactory.getLogger(CurrentClusterMeta.class);
 
 		private String clusterId;
 		private String clusterType;
 		private Map<String, CurrentShardMeta> clusterMetas = new ConcurrentHashMap<>();
-
+		//map<dc, RouteMeta>
+		private Map<String, RouteMeta> outgoingRoutes = new ConcurrentHashMap<>();
+		@JsonIgnore
+		private ChooseRouteStrategy chooseRouteStrategy;
 		public CurrentClusterMeta() {
 
 		}
@@ -361,6 +378,102 @@ public class CurrentMeta implements Releasable {
 			return clusterType;
 		}
 
+		private RouteMeta chooseRoute(int orgId, List<RouteMeta> dstDcRoutes, ChooseRouteStrategy strategy) {
+			if(dstDcRoutes == null) return null;
+			List<RouteMeta> resultsCandidates = new LinkedList<>();
+			dstDcRoutes.forEach(routeMeta -> {
+				if(ObjectUtils.equals(routeMeta.getOrgId(), orgId)){
+					resultsCandidates.add(routeMeta);
+				}
+			});
+
+			if(!resultsCandidates.isEmpty()){
+				return strategy.choose(resultsCandidates);
+			}
+
+
+			dstDcRoutes.forEach(routeMeta -> {
+				if(OrgUtil.isDefaultOrg(routeMeta.getOrgId())){
+					resultsCandidates.add(routeMeta);
+				}
+			});
+
+			return strategy.choose(resultsCandidates);
+		}
+
+		private Map<String, RouteMeta> chooseRoutes(List<RouteMeta> routes, ClusterMeta clusterMeta) {
+			if(routes == null || routes.isEmpty()){
+				return null;
+			}
+			logger.debug("routes: {}", routes);
+			Map<String, List<RouteMeta>> allDcRoutes = new ConcurrentHashMap<>();
+			routes.forEach(routeMeta -> {
+				String dcName = routeMeta.getDstDc();
+				List<RouteMeta> dcRoutes = MapUtils.getOrCreate(allDcRoutes, dcName, LinkedList::new);
+				dcRoutes.add(routeMeta);
+			});
+			Map<String, RouteMeta> allRoutes = new ConcurrentHashMap<>();
+			int orgId = clusterMeta.getOrgId();
+			for (String dcId : clusterMeta.getDcs().split("\\s*,\\s*")) {
+				if (currentDcId.equalsIgnoreCase(dcId)) continue;
+				RouteMeta route = chooseRoute(orgId, allDcRoutes.get(dcId), this.getChooseRouteStrategy());
+				if(route != null) allRoutes.put(dcId, route);
+			}
+			return allRoutes;
+		}
+
+		//callback changed dc list
+		List<String> diffRoutes(Map<String, RouteMeta> current, Map<String, RouteMeta> future) {
+			if(current == null || current.size() == 0) return new ArrayList<>(future.keySet());
+			if(future == null || future.size() == 0) return new ArrayList<>(current.keySet());
+
+			List<String> changedDcs = new LinkedList<>();
+			Set<String> comparedDcs = new HashSet<>();
+
+			for(Map.Entry<String, RouteMeta> entry : current.entrySet()) {
+				RouteMeta comparedRouteMeta = future.get(entry.getKey());
+				if(comparedRouteMeta == null || !comparedRouteMeta.getRouteInfo().equals(entry.getValue().getRouteInfo())) {
+					changedDcs.add(entry.getKey());
+				}
+				comparedDcs.add(entry.getKey());
+			}
+			for(Map.Entry<String , RouteMeta> entry: future.entrySet()) {
+				if(!comparedDcs.contains(entry.getKey())) {
+					changedDcs.add(entry.getKey());
+				}
+			}
+			return changedDcs;
+		}
+
+		public List<String> updateRoutes(List<RouteMeta> routes, ClusterMeta clusterMeta) {
+			Map<String, RouteMeta> outgoingRoutes = chooseRoutes(routes, clusterMeta);
+			List<String> changedDcs = diffRoutes(this.outgoingRoutes, outgoingRoutes);
+			this.outgoingRoutes = outgoingRoutes;
+			return changedDcs;
+		}
+
+		public RouteMeta getRouteByDcId(String dcId) {
+			return this.outgoingRoutes.get(dcId);
+		}
+
+		public void setOutgoingRoutes(Map<String, RouteMeta> outgoingRoutes) {
+			this.outgoingRoutes = outgoingRoutes;
+		}
+
+		public void setChooseRouteStrategy(ChooseRouteStrategy chooseRouteStrategy) {
+			this.chooseRouteStrategy = chooseRouteStrategy;
+		}
+
+		public ChooseRouteStrategy getChooseRouteStrategy() {
+			if(chooseRouteStrategy == null) {
+				this.chooseRouteStrategy = new ChooseRouteStrategy.HashCodeChooseRouteStrategy(clusterId.hashCode());
+			}
+			return this.chooseRouteStrategy;
+		}
+
+		public Map<String, RouteMeta> getOutgoingRoutes() {
+			return outgoingRoutes;
+		}
 	}
 
 

--- a/redis/redis-meta/src/main/java/com/ctrip/xpipe/redis/meta/server/meta/CurrentMetaManager.java
+++ b/redis/redis-meta/src/main/java/com/ctrip/xpipe/redis/meta/server/meta/CurrentMetaManager.java
@@ -9,6 +9,7 @@ import com.ctrip.xpipe.redis.core.entity.RouteMeta;
 import com.ctrip.xpipe.tuple.Pair;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -72,7 +73,9 @@ public interface CurrentMetaManager extends Observable {
 
 	Set<String> getUpstreamPeerDcs(String clusterId, String shardId);
 
-	List<RedisMeta> getAllPeerMasters(String clusterId, String shardId);
+	Map<String, RedisMeta> getAllPeerMasters(String clusterId, String shardId);
+
+	RouteMeta getClusterRouteByDcId(String dcId, String clusterId);
 
 	void removePeerMaster(String dcId, String clusterId, String shardId);
 

--- a/redis/redis-meta/src/main/java/com/ctrip/xpipe/redis/meta/server/meta/DcMetaCache.java
+++ b/redis/redis-meta/src/main/java/com/ctrip/xpipe/redis/meta/server/meta/DcMetaCache.java
@@ -5,6 +5,7 @@ import com.ctrip.xpipe.cluster.ClusterType;
 import com.ctrip.xpipe.redis.core.entity.*;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -23,6 +24,8 @@ public interface DcMetaCache extends Observable {
 	ClusterType getClusterType(String clusterId);
 
 	RouteMeta randomRoute(String clusterId);
+
+	List<RouteMeta> getAllRoutes();
 
 	KeeperContainerMeta getKeeperContainer(KeeperMeta keeperMeta);
 

--- a/redis/redis-meta/src/main/java/com/ctrip/xpipe/redis/meta/server/meta/impl/CurrentCRDTShardMeta.java
+++ b/redis/redis-meta/src/main/java/com/ctrip/xpipe/redis/meta/server/meta/impl/CurrentCRDTShardMeta.java
@@ -43,8 +43,8 @@ public class CurrentCRDTShardMeta extends AbstractCurrentShardMeta {
         return new HashSet<>(peerMasters.keySet());
     }
 
-    public List<RedisMeta> getAllPeerMasters() {
-        return new ArrayList<>(peerMasters.values());
+    public Map<String, RedisMeta> getAllPeerMasters() {
+        return new ConcurrentHashMap<>(peerMasters);
     }
 
     private RedisMeta cloneMasterMeta(RedisMeta peerMaster) {

--- a/redis/redis-meta/src/main/java/com/ctrip/xpipe/redis/meta/server/meta/impl/DefaultDcMetaCache.java
+++ b/redis/redis-meta/src/main/java/com/ctrip/xpipe/redis/meta/server/meta/impl/DefaultDcMetaCache.java
@@ -242,6 +242,11 @@ public class DefaultDcMetaCache extends AbstractLifecycleObservable implements D
 	}
 
 	@Override
+	public List<RouteMeta> getAllRoutes() {
+		return dcMetaManager.get().getAllRoutes();
+	}
+
+	@Override
 	public KeeperContainerMeta getKeeperContainer(KeeperMeta keeperMeta) {
 		return dcMetaManager.get().getKeeperContainer(keeperMeta);
 	}

--- a/redis/redis-meta/src/test/java/com/ctrip/xpipe/redis/meta/server/job/PeerMasterAdjustJobTest.java
+++ b/redis/redis-meta/src/test/java/com/ctrip/xpipe/redis/meta/server/job/PeerMasterAdjustJobTest.java
@@ -1,5 +1,6 @@
 package com.ctrip.xpipe.redis.meta.server.job;
 
+import com.ctrip.xpipe.api.endpoint.Endpoint;
 import com.ctrip.xpipe.endpoint.DefaultEndPoint;
 import com.ctrip.xpipe.exception.ExceptionUtils;
 import com.ctrip.xpipe.netty.NettySimpleMessageHandler;
@@ -131,15 +132,6 @@ public class PeerMasterAdjustJobTest extends AbstractMetaServerTest {
     }
 
     @Test
-    public void testJobInLowVersion() throws Exception {
-        version = "1.0.3";
-        peerMasterAdjustJob.execute().get();
-        Assert.assertEquals(2, peerofRequest.size());
-        Assert.assertTrue(peerofRequest.contains("peerof 2 10.0.0.2 7379"));
-        Assert.assertTrue(peerofRequest.contains("peerof 4 10.0.0.4 6379"));
-    }
-
-    @Test
     public void testNoChange() throws Exception {
         currentPeerMaster = new HashMap<>(expectPeerMaster);
         peerMasterAdjustJob.execute().get();
@@ -174,10 +166,10 @@ public class PeerMasterAdjustJobTest extends AbstractMetaServerTest {
         if (null != redisServer) redisServer.stop();
     }
 
-    private List<RedisMeta> mockUpstreamPeerMaster() {
-        List<RedisMeta> upstreamPeerMasters = new ArrayList<>();
+    private List<Pair<Long, Endpoint>> mockUpstreamPeerMaster() {
+        List<Pair<Long, Endpoint>> upstreamPeerMasters = new ArrayList<>();
         expectPeerMaster.forEach((gid, peerMaster) -> {
-            upstreamPeerMasters.add(new RedisMeta().setGid(gid).setIp(peerMaster.getKey()).setPort(peerMaster.getValue()));
+            upstreamPeerMasters.add(new Pair(gid, new DefaultEndPoint(peerMaster.getKey(), peerMaster.getValue())));
         });
 
         return upstreamPeerMasters;


### PR DESCRIPTION
1.修改peerof命令的传入参数（ip, port) -> endpoint，发送peerof 增加proxy
2.解析crdtinfo 命令返回结果修改 RedisMeta -> Pair<Long, Endpoint>，解析命令增加proxy
3.对比本地Peer信息和redis内Peer信息的job内对比对象修改 RedisMeta -> Pair<Long, Endpoint>，以及不再兼容没有返回gid的版本
4.创建对比Peer信息job时 创建List<Pair<Long, Endpoint>>
5.修改CurrentMetaManager::getAllPeerMasters返回值 Map<String, RedisMeta>
6.新增函数CurrentMetaManager::getAllRoutes 返回集群的所有routeMeta （Map)
7.route变更后触发 对比本地Peer信息和redis内Peer信息的job