### PR TITLE
fix(sec): upgrade io.netty:netty-all to 4.1.44.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>com.ctrip.framework</groupId>
@@ -41,7 +41,7 @@
         <spring-boot-maven-plugin.version>2.3.12.RELEASE</spring-boot-maven-plugin.version>
         <spring.velocity.version>1.4.3.RELEASE</spring.velocity.version>
         <netty3.version>3.10.5.Final</netty3.version>
-        <netty4.version>4.1.52.Final</netty4.version>
+        <netty4.version>4.1.44.Final</netty4.version>
         <ctrip-framework-foundation.version>1.8.11</ctrip-framework-foundation.version>
         <ctrip-apollo.version>0.6.7</ctrip-apollo.version>
         <cat.version>3.3.32</cat.version>
@@ -63,7 +63,7 @@
         <qconfig.client.version>1.6.11</qconfig.client.version>
         <qtracer.version>1.2.4</qtracer.version>
         <netty.boringssl.version>2.0.12.Final</netty.boringssl.version>
-        <netty4.version>4.1.28.Final</netty4.version>
+        <netty4.version>4.1.44.Final</netty4.version>
         <zstd.version>1.3.6-1</zstd.version>
         <jackson.version>2.10.3</jackson.version>
         <soa.version>2.21.17</soa.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in io.netty:netty-all 4.1.28.Final
- [CVE-2019-16869](https://www.oscs1024.com/hd/CVE-2019-16869)


### What did I do？
Upgrade io.netty:netty-all from 4.1.28.Final to 4.1.44.Final for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS