### PR TITLE
bugfix: dcmeta avoid return empty

### DIFF
--- a/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/controller/api/metaserver/ConsoleController.java
+++ b/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/controller/api/metaserver/ConsoleController.java
@@ -47,7 +47,7 @@ public class ConsoleController extends AbstractConsoleController {
 
 	@RequestMapping(value = "/dc/{dcId}", method = RequestMethod.GET, produces={MediaType.APPLICATION_JSON_UTF8_VALUE})
 	public String getDcMeta(@PathVariable String dcId, @RequestParam(value="format", required = false) String format,
-							@RequestParam(value ="types", required = false) Set<String> types) {
+							@RequestParam(value ="types", required = false) Set<String> types) throws Exception {
 		DcMeta result;
 		if (null != types && !types.isEmpty()) {
 			result = dcMetaService.getDcMeta(dcId, types);

--- a/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/service/impl/ReplDirectionServiceImpl.java
+++ b/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/service/impl/ReplDirectionServiceImpl.java
@@ -49,12 +49,15 @@ public class ReplDirectionServiceImpl  extends AbstractConsoleService<ReplDirect
         });
 
         replDirectionTbls.forEach(replDirectionTbl -> {
-            if (replDirectionTbl.getSrcDcId() == 0) {
-                replDirectionTbl.setSrcDcId(clusterIdActiveDcIdMap.get(replDirectionTbl.getClusterId()));
-            }
+            Long dcId = clusterIdActiveDcIdMap.get(replDirectionTbl.getClusterId());
+            if (dcId != null) {
+                if (replDirectionTbl.getSrcDcId() == 0) {
+                    replDirectionTbl.setSrcDcId(dcId);
+                }
 
-            if (replDirectionTbl.getFromDcId() == 0) {
-                replDirectionTbl.setFromDcId(clusterIdActiveDcIdMap.get(replDirectionTbl.getClusterId()));
+                if (replDirectionTbl.getFromDcId() == 0) {
+                    replDirectionTbl.setFromDcId(dcId);
+                }
             }
         });
 

--- a/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/service/meta/DcMetaService.java
+++ b/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/service/meta/DcMetaService.java
@@ -12,10 +12,10 @@ import java.util.Set;
  */
 public interface DcMetaService {
 	
-	DcMeta getDcMeta(String dcName);
+	DcMeta getDcMeta(String dcName) throws Exception;
 
-	DcMeta getDcMeta(String dcName, Set<String> allowTypes);
+	DcMeta getDcMeta(String dcName, Set<String> allowTypes) throws Exception;
 
-	Map<String, DcMeta> getAllDcMetas();
+	Map<String, DcMeta> getAllDcMetas() throws Exception;
 	
 }

--- a/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/service/meta/impl/AdvancedDcMetaService.java
+++ b/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/service/meta/impl/AdvancedDcMetaService.java
@@ -116,12 +116,12 @@ public class AdvancedDcMetaService implements DcMetaService {
     }
 
     @Override
-    public DcMeta getDcMeta(String dcName) {
+    public DcMeta getDcMeta(String dcName) throws Exception{
         return getDcMeta(dcName, consoleConfig.getOwnClusterType());
     }
 
     @Override
-    public DcMeta getDcMeta(String dcName, Set<String> allowTypes) {
+    public DcMeta getDcMeta(String dcName, Set<String> allowTypes) throws Exception {
         List<DcTbl> dcTblList = dcService.findAllDcs();
         DcTbl dcTbl = null;
         for (DcTbl dt : dcTblList) {
@@ -147,17 +147,13 @@ public class AdvancedDcMetaService implements DcMetaService {
                 applierService, factory, consoleConfig);
         chain.add(retry3TimesUntilSuccess(builder));
 
-        try {
-            chain.execute().get();
-        } catch (Exception e) {
-            logger.error("[queryDcMeta] ", e);
-        }
+        chain.execute().get();
 
         return dcMeta;
     }
 
     @Override
-    public Map<String, DcMeta> getAllDcMetas() {
+    public Map<String, DcMeta> getAllDcMetas() throws Exception {
         List<DcTbl> dcTblList = dcService.findAllDcs();
         ParallelCommandChain chain = new ParallelCommandChain(executors, false);
         Map<String, DcMeta> dcMetaMap = new HashMap<>();
@@ -180,11 +176,7 @@ public class AdvancedDcMetaService implements DcMetaService {
                 applierService, factory, consoleConfig);
         chain.add(retry3TimesUntilSuccess(builder));
 
-        try {
-            chain.execute().get();
-        } catch (Exception e) {
-            logger.error("[queryAllDcMetas] ", e);
-        }
+        chain.execute().get();
 
         return dcMetaMap;
     }

--- a/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/service/meta/impl/AdvancedDcMetaService.java
+++ b/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/service/meta/impl/AdvancedDcMetaService.java
@@ -1,6 +1,7 @@
 package com.ctrip.xpipe.redis.console.service.meta.impl;
 
 import com.ctrip.xpipe.api.command.Command;
+import com.ctrip.xpipe.api.monitor.EventMonitor;
 import com.ctrip.xpipe.command.AbstractCommand;
 import com.ctrip.xpipe.command.DefaultRetryCommandFactory;
 import com.ctrip.xpipe.command.ParallelCommandChain;
@@ -147,7 +148,12 @@ public class AdvancedDcMetaService implements DcMetaService {
                 applierService, factory, consoleConfig);
         chain.add(retry3TimesUntilSuccess(builder));
 
-        chain.execute().get();
+        try {
+            chain.execute().get();
+        } catch (Throwable th) {
+            EventMonitor.DEFAULT.logAlertEvent("getDcMeta throw exception");
+            throw th;
+        }
 
         return dcMeta;
     }
@@ -176,7 +182,12 @@ public class AdvancedDcMetaService implements DcMetaService {
                 applierService, factory, consoleConfig);
         chain.add(retry3TimesUntilSuccess(builder));
 
-        chain.execute().get();
+        try {
+            chain.execute().get();
+        } catch (Throwable th) {
+            EventMonitor.DEFAULT.logAlertEvent("getAllDcMetas throw exception");
+            throw th;
+        }
 
         return dcMetaMap;
     }

--- a/redis/redis-console/src/test/java/com/ctrip/xpipe/redis/console/migration/model/DefaultMigrationClusterTest.java
+++ b/redis/redis-console/src/test/java/com/ctrip/xpipe/redis/console/migration/model/DefaultMigrationClusterTest.java
@@ -154,7 +154,7 @@ public class DefaultMigrationClusterTest extends AbstractMigrationTest {
 	
 	@Test
 	@DirtiesContext
-	public void testCancelOnMigrating() {
+	public void testCancelOnMigrating() throws Exception {
 		mockSuccessCheckCommand(migrationCommandBuilder,"cluster1", "shard1", dcB, dcB);
 		mockSuccessPrevPrimaryDcCommand(migrationCommandBuilder,"cluster1", "shard1", dcA);
 		mockFailNewPrimaryDcCommand(migrationCommandBuilder,"cluster1", "shard1", dcB,new Throwable("mocked new fail"));

--- a/redis/redis-console/src/test/java/com/ctrip/xpipe/redis/console/service/ClusterMetaServiceTest.java
+++ b/redis/redis-console/src/test/java/com/ctrip/xpipe/redis/console/service/ClusterMetaServiceTest.java
@@ -71,7 +71,7 @@ public class ClusterMetaServiceTest extends AbstractConsoleIntegrationTest {
 	
 	@Test
 	@DirtiesContext
-	public void testGetDifferentActiveDcForDcMetaWhileMigrating() {
+	public void testGetDifferentActiveDcForDcMetaWhileMigrating() throws Exception {
 		ClusterTbl clusterA = clusterService.find(clusterName1);
 		Assert.assertEquals(ClusterStatus.Normal.toString(), clusterA.getStatus());
 		ClusterTbl clusterB = clusterService.find(clusterName2);

--- a/redis/redis-console/src/test/java/com/ctrip/xpipe/redis/console/service/impl/DcServiceImplTest.java
+++ b/redis/redis-console/src/test/java/com/ctrip/xpipe/redis/console/service/impl/DcServiceImplTest.java
@@ -178,7 +178,7 @@ public class DcServiceImplTest extends AbstractConsoleIntegrationTest {
     }
 
     @Test
-    public void testFindAllDcsRichinfo() {
+    public void testFindAllDcsRichinfo() throws Exception {
 
         Map<String, DcMeta> dcMetaMap = new HashMap<>();
         dcMetaMap.put("jq".toUpperCase(), xpipeMeta.findDc("jq"));

--- a/redis/redis-console/src/test/java/com/ctrip/xpipe/redis/console/service/meta/impl/AdvancedDcMetaServiceTest.java
+++ b/redis/redis-console/src/test/java/com/ctrip/xpipe/redis/console/service/meta/impl/AdvancedDcMetaServiceTest.java
@@ -92,7 +92,7 @@ public class AdvancedDcMetaServiceTest extends AbstractConsoleIntegrationTest {
     }
 
     @Test
-    public void testGetDcMeta() {
+    public void testGetDcMeta() throws Exception {
         long start = System.currentTimeMillis();
         DcMeta dcMeta = service.getDcMeta("jq");
         long end = System.currentTimeMillis();
@@ -101,7 +101,7 @@ public class AdvancedDcMetaServiceTest extends AbstractConsoleIntegrationTest {
     }
 
     @Test
-    public void testGetDcMeta2() {
+    public void testGetDcMeta2() throws Exception {
         long start = System.currentTimeMillis();
         for(int i = 0; i < 100; i++) {
             dcMetaService.getDcMeta(dcNames[(1&i)]);
@@ -129,7 +129,7 @@ public class AdvancedDcMetaServiceTest extends AbstractConsoleIntegrationTest {
     }
 
     @Test
-    public void testClusterOrgInfo() {
+    public void testClusterOrgInfo() throws Exception {
         List<ClusterTbl> clusterTbls = clusterService.findAllClustersWithOrgInfo();
 
         ClusterTbl clusterTbl = clusterTbls.get(3);
@@ -150,7 +150,7 @@ public class AdvancedDcMetaServiceTest extends AbstractConsoleIntegrationTest {
 
     @Ignore
     @Test
-    public void testHangForever() {
+    public void testHangForever() throws Exception {
 //        proxyService.deleteProxy();
         dcMetaService.getDcMeta("jq");
     }

--- a/redis/redis-console/src/test/java/com/ctrip/xpipe/redis/console/service/meta/impl/AdvancedDcMetaServiceTestForConcurrent.java
+++ b/redis/redis-console/src/test/java/com/ctrip/xpipe/redis/console/service/meta/impl/AdvancedDcMetaServiceTestForConcurrent.java
@@ -51,7 +51,7 @@ public class AdvancedDcMetaServiceTestForConcurrent extends AbstractConsoleInteg
     private RedisService redisService;
 
     @Test
-    public void testGetDcMeta() {
+    public void testGetDcMeta() throws Exception {
         DcMeta jqFuture = service.getDcMeta("NTGXH");
         DcMeta oyFuture = service.getDcMeta("UAT");
 
@@ -105,7 +105,7 @@ public class AdvancedDcMetaServiceTestForConcurrent extends AbstractConsoleInteg
     }
 
     @Test
-    public void testDcComparator() {
+    public void testDcComparator() throws Exception {
         DcMeta jqFuture = service.getDcMeta("NTGXH");
         jqFuture.addCluster(new ClusterMeta("add"));
 
@@ -117,7 +117,7 @@ public class AdvancedDcMetaServiceTestForConcurrent extends AbstractConsoleInteg
     }
 
     @Test
-    public void testDcComparator2() {
+    public void testDcComparator2() throws Exception {
         DcMeta jqFuture = service.getDcMeta("NTGXH");
 
         jqFuture.removeCluster(jqFuture.getClusters().keySet().iterator().next());
@@ -130,7 +130,7 @@ public class AdvancedDcMetaServiceTestForConcurrent extends AbstractConsoleInteg
     }
 
     @Test
-    public void testDcComparator3() {
+    public void testDcComparator3() throws Exception {
         DcMeta jqFuture = service.getDcMeta("NTGXH");
 
         ClusterMeta clusterMeta = jqFuture.getClusters().values().iterator().next();


### PR DESCRIPTION
when build dcmeta throw exception, throw it to caller instead of catching
fix npe in ReplDirectionServiceImpl