### PR TITLE
修复当有多个异构机房时，applier的状态更新失败的问题

### DIFF
--- a/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/service/impl/ApplierServiceImpl.java
+++ b/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/service/impl/ApplierServiceImpl.java
@@ -15,6 +15,7 @@ import com.ctrip.xpipe.spring.AbstractSpringConfigContext;
 import com.ctrip.xpipe.utils.MapUtils;
 import com.ctrip.xpipe.utils.MathUtil;
 import com.ctrip.xpipe.utils.ObjectUtils;
+import com.ctrip.xpipe.utils.VisibleForTesting;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -162,14 +163,15 @@ public class ApplierServiceImpl extends AbstractConsoleService<ApplierTblDao> im
         }
 
         List<ApplierTbl> applierTbls = applierDao.findByShard(shardTbl.getId());
+        List<ApplierTbl> result = new ArrayList<>();
         for (ApplierTbl applierTbl : applierTbls) {
             AppliercontainerTbl appliercontainerTbl = appliercontainerService.findAppliercontainerTblById(applierTbl.getContainerId());
-            if (dcTbl.getId() != appliercontainerTbl.getAppliercontainerDc()) {
-                applierTbls.remove(applierTbl);
+            if (dcTbl.getId() == appliercontainerTbl.getAppliercontainerDc()) {
+                result.add(applierTbl);
             }
         }
 
-        return applierTbls;
+        return result;
     }
 
     @Override
@@ -469,6 +471,16 @@ public class ApplierServiceImpl extends AbstractConsoleService<ApplierTblDao> im
         }
 
         return ipUsedPortsMap;
+    }
+
+    @VisibleForTesting
+    public void setApplierDao(ApplierDao applierDao) {
+        this.applierDao = applierDao;
+    }
+
+    @VisibleForTesting
+    public void setAppliercontainerService(AppliercontainerService appliercontainerService) {
+        this.appliercontainerService = appliercontainerService;
     }
 
 }

--- a/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/service/impl/ApplierServiceImpl.java
+++ b/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/service/impl/ApplierServiceImpl.java
@@ -483,4 +483,13 @@ public class ApplierServiceImpl extends AbstractConsoleService<ApplierTblDao> im
         this.appliercontainerService = appliercontainerService;
     }
 
+    @VisibleForTesting
+    public AppliercontainerService getAppliercontainerService() {
+        return appliercontainerService;
+    }
+
+    @VisibleForTesting
+    public ApplierDao getApplierDao() {
+        return applierDao;
+    }
 }

--- a/redis/redis-console/src/test/java/com/ctrip/xpipe/redis/console/service/impl/ApplierServiceImplTest.java
+++ b/redis/redis-console/src/test/java/com/ctrip/xpipe/redis/console/service/impl/ApplierServiceImplTest.java
@@ -1,20 +1,17 @@
 package com.ctrip.xpipe.redis.console.service.impl;
 
-import com.ctrip.xpipe.redis.console.model.ApplierTbl;
-import com.ctrip.xpipe.redis.console.model.AppliercontainerTbl;
-import com.ctrip.xpipe.redis.console.model.RedisTbl;
-import com.ctrip.xpipe.redis.console.model.ShardModel;
-import com.ctrip.xpipe.redis.console.service.ApplierBasicInfo;
-import com.ctrip.xpipe.redis.console.service.ApplierService;
-import com.ctrip.xpipe.redis.console.service.AppliercontainerService;
-import com.ctrip.xpipe.redis.console.service.RedisService;
+import com.ctrip.xpipe.redis.console.dao.ApplierDao;
+import com.ctrip.xpipe.redis.console.model.*;
+import com.ctrip.xpipe.redis.console.service.*;
 import com.ctrip.xpipe.redis.console.service.model.ShardModelService;
 import org.assertj.core.util.Lists;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 public class ApplierServiceImplTest extends AbstractServiceImplTest{
@@ -30,6 +27,31 @@ public class ApplierServiceImplTest extends AbstractServiceImplTest{
 
     @Autowired
     RedisService redisService;
+
+    @Autowired
+    DcService dcService;
+
+    @Test
+    public void testFindAppliersByDcAndShard() {
+        List<ApplierTbl> applierTblList = new ArrayList<>();
+        applierTblList.add(new ApplierTbl().setContainerId(1));
+        applierTblList.add(new ApplierTbl().setContainerId(2));
+        applierTblList.add(new ApplierTbl().setContainerId(1));
+        applierTblList.add(new ApplierTbl().setContainerId(2));
+
+        ApplierDao mockedApplierDao = Mockito.mock(ApplierDao.class);
+        Mockito.when(mockedApplierDao.findByShard(Mockito.anyLong())).thenReturn(applierTblList);
+
+        AppliercontainerService spy = Mockito.spy(appliercontainerService);
+        Mockito.when(spy.findAppliercontainerTblById(1)).thenReturn(new AppliercontainerTbl().setAppliercontainerDc(1));
+        Mockito.when(spy.findAppliercontainerTblById(2)).thenReturn(new AppliercontainerTbl().setAppliercontainerDc(2));
+
+        ((ApplierServiceImpl) applierService).setAppliercontainerService(spy);
+        ((ApplierServiceImpl) applierService).setApplierDao(mockedApplierDao);
+
+        List<ApplierTbl> result = applierService.findAppliersByDcAndShard("jq", "cluster1", "shard1");
+        Assert.assertEquals(2, result.size());
+    }
 
     @Test
     public void testFind() {

--- a/redis/redis-console/src/test/java/com/ctrip/xpipe/redis/console/service/impl/ApplierServiceImplTest.java
+++ b/redis/redis-console/src/test/java/com/ctrip/xpipe/redis/console/service/impl/ApplierServiceImplTest.java
@@ -46,11 +46,16 @@ public class ApplierServiceImplTest extends AbstractServiceImplTest{
         Mockito.when(spy.findAppliercontainerTblById(1)).thenReturn(new AppliercontainerTbl().setAppliercontainerDc(1));
         Mockito.when(spy.findAppliercontainerTblById(2)).thenReturn(new AppliercontainerTbl().setAppliercontainerDc(2));
 
+        AppliercontainerService tmpAppliercontainerService = ((ApplierServiceImpl) applierService).getAppliercontainerService();
+        ApplierDao tmpApplierDao = ((ApplierServiceImpl) applierService).getApplierDao();
         ((ApplierServiceImpl) applierService).setAppliercontainerService(spy);
         ((ApplierServiceImpl) applierService).setApplierDao(mockedApplierDao);
 
         List<ApplierTbl> result = applierService.findAppliersByDcAndShard("jq", "cluster1", "shard1");
         Assert.assertEquals(2, result.size());
+
+        ((ApplierServiceImpl) applierService).setAppliercontainerService(tmpAppliercontainerService);
+        ((ApplierServiceImpl) applierService).setApplierDao(tmpApplierDao);
     }
 
     @Test


### PR DESCRIPTION
fix applier active status updated failed problem when more than one hetero dc exists, by fixing concurrentModification exception
