### PR TITLE
remove not recover alert for RepeatAlert and delay alert

### DIFF
--- a/redis/redis-checker/src/main/java/com/ctrip/xpipe/redis/checker/alert/message/subscriber/AlertEntityDelaySubscriber.java
+++ b/redis/redis-checker/src/main/java/com/ctrip/xpipe/redis/checker/alert/message/subscriber/AlertEntityDelaySubscriber.java
@@ -45,6 +45,9 @@ public class AlertEntityDelaySubscriber extends AbstractAlertEntitySubscriber {
     @Autowired
     private DelayAlertRecoverySubscriber delayAlertRecoverySubscriber;
 
+    @Autowired
+    private RepeatAlertEntitySubscriber repeatAlertEntitySubscriber;
+
     @PostConstruct
     public void initCleaner() {
         scheduled.scheduleWithFixedDelay(new AbstractExceptionLogTask() {
@@ -141,6 +144,7 @@ public class AlertEntityDelaySubscriber extends AbstractAlertEntitySubscriber {
         if(alert.getAlertType().delayedSendingTime() != 0) {
             //  延迟发布的要推送主动给AlertRecoverySubscriber，这边主动触发
             delayAlertRecoverySubscriber.addDelayAlerts(alert);
+            repeatAlertEntitySubscriber.addDelayAlert(alert);
         }
     }
 

--- a/redis/redis-checker/src/main/java/com/ctrip/xpipe/redis/checker/alert/message/subscriber/RepeatAlertEntitySubscriber.java
+++ b/redis/redis-checker/src/main/java/com/ctrip/xpipe/redis/checker/alert/message/subscriber/RepeatAlertEntitySubscriber.java
@@ -79,6 +79,22 @@ public class RepeatAlertEntitySubscriber extends AbstractAlertEntitySubscriber {
         if(ignoreAlert(alert) || alert.getAlertType().onlyTrack()) {
             return;
         }
+        if(alert.getAlertType().delayedSendingTime() != 0) {
+            // 延迟告警的通过 addDelayAlert 函数加入
+            return;
+        }
+        if(alert.getAlertType().reportRecovery()) {
+            // 没有恢复逻辑
+            return;
+        }
+        addAlert(alert);
+    }
+
+    public void addDelayAlert(AlertEntity alert) {
+        addAlert(alert);
+    }
+
+    private void addAlert(AlertEntity alert) {
         synchronized (this) {
             holderManager.holdAlert(alert);
         }


### PR DESCRIPTION
1. RepeatAlertEntitySubscriber 每隔30分钟发一次，像MARK_INSTANCE_UP 这种如果是8分钟之内的，会重复发一次，但是MARK_INSTANCE_UP本身没有恢复的逻辑。
2. 延迟类告警不直接通过doProcessAlert 加入，避免30分钟周期发送时刚好延迟告警刚好在8分钟之内没有恢复