### PR TITLE
Add AZ tag to Redis nodes when registering to Beacon

### DIFF
--- a/core/src/main/java/com/ctrip/xpipe/api/migration/OuterClientService.java
+++ b/core/src/main/java/com/ctrip/xpipe/api/migration/OuterClientService.java
@@ -655,6 +655,16 @@ public interface OuterClientService extends Ordered{
 			this.idc = idc;
 		}
 
+		private String az;
+
+		public String getAz() {
+			return az;
+		}
+
+		public void setAz(String az) {
+			this.az = az;
+		}
+
 	}
 
 	@JsonIgnoreProperties(ignoreUnknown = true)

--- a/core/src/main/java/com/ctrip/xpipe/api/migration/auto/data/MonitorClusterMeta.java
+++ b/core/src/main/java/com/ctrip/xpipe/api/migration/auto/data/MonitorClusterMeta.java
@@ -73,6 +73,7 @@ public class MonitorClusterMeta {
         for(MonitorGroupMeta group : nodeList) {
             builder.append(group.getName())
                     .append(group.getIdc())
+                    .append(group.getAz())
                     .append(group.isMasterGroup())
                     .append(group.getNodes());
         }
@@ -90,7 +91,9 @@ public class MonitorClusterMeta {
                     continue;
                 }
                 // For sentinel mode hash check, master flag should be ignored.
-                groups.add(new MonitorGroupMeta(groupMeta.getName(), groupMeta.getIdc(), groupMeta.getNodes(), false));
+                MonitorGroupMeta group = new MonitorGroupMeta(groupMeta.getName(), groupMeta.getIdc(), groupMeta.getNodes(), false);
+                group.setAz(groupMeta.getAz());
+                groups.add(group);
             }
         }
         return groups;

--- a/core/src/main/java/com/ctrip/xpipe/api/migration/auto/data/MonitorGroupMeta.java
+++ b/core/src/main/java/com/ctrip/xpipe/api/migration/auto/data/MonitorGroupMeta.java
@@ -29,6 +29,8 @@ public class MonitorGroupMeta {
 
     private String idc;
 
+    private String az;
+
     private Set<HostPort> nodes;
 
     private Boolean down;
@@ -41,6 +43,10 @@ public class MonitorGroupMeta {
 
     public String getIdc() {
         return idc;
+    }
+
+    public String getAz() {
+        return az;
     }
 
     public Boolean getDown() {
@@ -58,6 +64,10 @@ public class MonitorGroupMeta {
 
     public void setIdc(String idc) {
         this.idc = idc;
+    }
+
+    public void setAz(String az) {
+        this.az = az;
     }
 
     public void setDown(Boolean down) {
@@ -83,12 +93,13 @@ public class MonitorGroupMeta {
         MonitorGroupMeta that = (MonitorGroupMeta) o;
         return Objects.equals(name, that.name) &&
                 Objects.equals(idc, that.idc) &&
+                Objects.equals(az, that.az) &&
                 Objects.equals(nodes, that.nodes);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, idc, nodes);
+        return Objects.hash(name, idc, az, nodes);
     }
 
     @Override
@@ -96,6 +107,7 @@ public class MonitorGroupMeta {
         return "BeaconGroupModel{" +
                 "name='" + name + '\'' +
                 ", idc='" + idc + '\'' +
+                ", az='" + az + '\'' +
                 ", nodes=" + nodes +
                 ", down=" + down +
                 ", masterGroup=" + masterGroup +

--- a/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/controller/api/data/MetaUpdate.java
+++ b/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/controller/api/data/MetaUpdate.java
@@ -342,7 +342,7 @@ public class MetaUpdate extends AbstractConsoleController {
         // Fill in redis, keeper
         for(RedisCreateInfo redisCreateInfo : redisCreateInfos) {
             String dcId = outerDcToInnerDc(redisCreateInfo.getDcId());
-            redisService.insertRedises(dcId, clusterName, shardName, redisCreateInfo.getRedisAddresses());
+            redisService.insertRedises(dcId, clusterName, shardName, redisCreateInfo.getRedisAddresses(), redisCreateInfo.getAzId());
         }
         addKeepers(clusterTbl, shardTbl, redisCreateInfos);
     }

--- a/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/controller/api/data/meta/RedisCreateInfo.java
+++ b/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/controller/api/data/meta/RedisCreateInfo.java
@@ -19,6 +19,7 @@ public class RedisCreateInfo extends AbstractCreateInfo {
     private String clusterId;
     private String shardName;
     private String redises;
+    private Long azId;
 
     @Override
     public void check() throws CheckFailException {
@@ -72,5 +73,14 @@ public class RedisCreateInfo extends AbstractCreateInfo {
 
     public void setClusterId(String clusterId) {
         this.clusterId = clusterId;
+    }
+
+    public Long getAzId() {
+        return azId;
+    }
+
+    public RedisCreateInfo setAzId(Long azId) {
+        this.azId = azId;
+        return this;
     }
 }

--- a/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/resources/ClusterMetaSynchronizer.java
+++ b/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/resources/ClusterMetaSynchronizer.java
@@ -33,6 +33,7 @@ public class ClusterMetaSynchronizer {
     private ClusterService clusterService;
     private ShardService shardService;
     private RedisService redisService;
+    private AzService azService;
     private DcService dcService;
     private OrganizationService organizationService;
     private SentinelBalanceService sentinelBalanceService;
@@ -45,7 +46,7 @@ public class ClusterMetaSynchronizer {
                                    RedisService redisService, OrganizationService organizationService,
                                    SentinelBalanceService sentinelBalanceService, ConsoleConfig consoleConfig,
                                    ClusterTypeUpdateEventFactory clusterTypeUpdateEventFactory,
-                                   String dcId
+                                   AzService azService, String dcId
     ) {
         this.added = added;
         this.removed = removed;
@@ -58,6 +59,7 @@ public class ClusterMetaSynchronizer {
         this.sentinelBalanceService = sentinelBalanceService;
         this.consoleConfig = consoleConfig;
         this.clusterTypeUpdateEventFactory = clusterTypeUpdateEventFactory;
+        this.azService = azService;
         this.dcId = dcId;
     }
 
@@ -107,7 +109,7 @@ public class ClusterMetaSynchronizer {
                             return;
                         }
 
-                        new ShardMetaSynchronizer(Sets.newHashSet(toAdd.getShards().values()), null, null, redisService, shardService, sentinelBalanceService, consoleConfig, dcId).sync();
+                        new ShardMetaSynchronizer(Sets.newHashSet(toAdd.getShards().values()), null, null, redisService, shardService, sentinelBalanceService, consoleConfig, azService, dcId).sync();
                     } catch (Exception e) {
                         logger.error("[ClusterMetaSynchronizer][add]{}", toAdd, e);
                     }
@@ -190,7 +192,7 @@ public class ClusterMetaSynchronizer {
                         notifyIfClusterTypeUpdated(currentClusterTye, currentClusterTbl);
                     }
                     new ShardMetaSynchronizer(clusterMetaComparator.getAdded(), clusterMetaComparator.getRemoved(), clusterMetaComparator.getMofified(),
-                            redisService, shardService, sentinelBalanceService, consoleConfig, dcId).sync();
+                            redisService, shardService, sentinelBalanceService, consoleConfig, azService, dcId).sync();
                 } catch (Exception e) {
                     logger.error("[ClusterMetaSynchronizer][update]{} -> {}", ((ClusterMetaComparator) metaComparator).getCurrent(), ((ClusterMetaComparator) metaComparator).getFuture(), e);
                 }

--- a/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/resources/ConsolePortalService.java
+++ b/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/resources/ConsolePortalService.java
@@ -215,10 +215,15 @@ public class ConsolePortalService extends AbstractService {
     }
 
     public void insertRedises(String dcId, String clusterId, String shardId, List<Pair<String, Integer>> addrs) {
+        insertRedises(dcId, clusterId, shardId, addrs, null);
+    }
+
+    public void insertRedises(String dcId, String clusterId, String shardId, List<Pair<String, Integer>> addrs, Long azId) {
         RedisCreateInfo redisCreateInfo = new RedisCreateInfo();
         redisCreateInfo.setDcId(dcId);
         redisCreateInfo.setClusterId(clusterId);
         redisCreateInfo.setShardName(shardId);
+        redisCreateInfo.setAzId(azId);
         List<String> redisAddrs = new ArrayList<>();
         for (Pair<String, Integer> addr : addrs) {
             redisAddrs.add(addr.getKey() + ":" + addr.getValue());

--- a/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/resources/DcMetaSynchronizer.java
+++ b/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/resources/DcMetaSynchronizer.java
@@ -40,7 +40,7 @@ public class DcMetaSynchronizer implements MetaSynchronizer {
                               ClusterService clusterService, DcService dcService,
                               OrganizationService organizationService, SentinelBalanceService sentinelBalanceService,
                               ClusterTypeUpdateEventFactory clusterTypeUpdateEventFactory, OuterClientService outerClientService,
-                              String dcId
+                              AzService azService, String dcId
 
     ) {
         this.consoleConfig = consoleConfig;
@@ -53,6 +53,7 @@ public class DcMetaSynchronizer implements MetaSynchronizer {
         this.sentinelBalanceService = sentinelBalanceService;
         this.clusterTypeUpdateEventFactory = clusterTypeUpdateEventFactory;
         this.outerClientService = outerClientService;
+        this.azService = azService;
         this.currentDcId = dcId;
         this.scheduledExecutorService = Executors.newScheduledThreadPool(1, XpipeThreadFactory.create("XPipe-Meta-Sync-" + dcId));
     }
@@ -72,6 +73,8 @@ public class DcMetaSynchronizer implements MetaSynchronizer {
     private ConsoleConfig consoleConfig;
 
     private SentinelBalanceService sentinelBalanceService;
+
+    private AzService azService;
 
     private ClusterTypeUpdateEventFactory clusterTypeUpdateEventFactory;
 
@@ -114,7 +117,7 @@ public class DcMetaSynchronizer implements MetaSynchronizer {
                     new ClusterMetaSynchronizer(dcMetaComparator.getAdded(), dcMetaComparator.getRemoved(), dcMetaComparator.getMofified(),
                             dcService, clusterService, shardService, redisService,
                             organizationService, sentinelBalanceService, consoleConfig,
-                            clusterTypeUpdateEventFactory, currentDcId).sync();
+                            clusterTypeUpdateEventFactory, azService, currentDcId).sync();
                 } catch (Throwable e) {
                     logger.error("[DcMetaSynchronizer][sync]", e);
                 }
@@ -268,6 +271,7 @@ public class DcMetaSynchronizer implements MetaSynchronizer {
             redisMeta.setMaster("");
         else
             redisMeta.setMaster(XPipeConsoleConstant.DEFAULT_ADDRESS);
+        redisMeta.setAz(outer.getAz());
         return redisMeta;
     }
 
@@ -276,6 +280,7 @@ public class DcMetaSynchronizer implements MetaSynchronizer {
         redisMeta.setIp(origin.getIp());
         redisMeta.setPort(origin.getPort());
         redisMeta.setMaster(origin.getMaster());
+        redisMeta.setAz(origin.getAz());
         return redisMeta;
     }
 

--- a/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/resources/MetaSynchronizer.java
+++ b/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/resources/MetaSynchronizer.java
@@ -75,6 +75,9 @@ public class MetaSynchronizer {
 
     private SentinelBalanceService sentinelBalanceService;
 
+    @Autowired
+    private AzService azService;
+
     private ClusterTypeUpdateEventFactory clusterTypeUpdateEventFactory;
 
     @PostConstruct
@@ -97,7 +100,7 @@ public class MetaSynchronizer {
                 // 还未加入，需要添加
                 dcMetaSynchronizers.put(dc, new DcMetaSynchronizer(consoleConfig, metaCache, redisService, shardService,
                         clusterService, dcService, organizationService, sentinelBalanceService,
-                        clusterTypeUpdateEventFactory, outerClientService, dc));
+                        clusterTypeUpdateEventFactory, outerClientService, azService, dc));
                 dcMetaSynchronizers.get(dc).start();
             }
         }

--- a/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/resources/RedisMetaSynchronizer.java
+++ b/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/resources/RedisMetaSynchronizer.java
@@ -1,6 +1,7 @@
 package com.ctrip.xpipe.redis.console.resources;
 
 import com.ctrip.xpipe.monitor.CatEventMonitor;
+import com.ctrip.xpipe.redis.console.service.AzService;
 import com.ctrip.xpipe.redis.console.service.RedisService;
 import com.ctrip.xpipe.redis.core.entity.ClusterMeta;
 import com.ctrip.xpipe.redis.core.entity.RedisMeta;
@@ -18,6 +19,7 @@ import java.util.Set;
 public class RedisMetaSynchronizer implements MetaSynchronizer {
     private static Logger logger = LoggerFactory.getLogger(RedisMetaSynchronizer.class);
     protected RedisService redisService;
+    protected AzService azService;
     private Set<InstanceNode> added;
     private Set<InstanceNode> removed;
     private Set<MetaComparator> modified;
@@ -26,12 +28,13 @@ public class RedisMetaSynchronizer implements MetaSynchronizer {
 
     public RedisMetaSynchronizer(Set<InstanceNode> added, Set<InstanceNode> removed,
                                  Set<MetaComparator> modified, RedisService redisService,
-                                 String dcId
+                                 AzService azService, String dcId
     ) {
         this.added = added;
         this.removed = removed;
         this.modified = modified;
         this.redisService = redisService;
+        this.azService = azService;
         this.dcId = dcId;
     }
 
@@ -64,19 +67,30 @@ public class RedisMetaSynchronizer implements MetaSynchronizer {
         try {
             if (added == null || added.isEmpty())
                 return;
-            String clusterId = "";
-            String shardId = "";
-            List<Pair<String, Integer>> toAdded = new ArrayList<>();
-            List<RedisMeta> toUpdateMaster = new ArrayList<>();
             for (InstanceNode instanceNode : added) {
-                toAdded.add(new Pair<>(instanceNode.getIp(), instanceNode.getPort()));
-                toUpdateMaster.add((RedisMeta) instanceNode);
-                clusterId = ((ClusterMeta) ((RedisMeta) instanceNode).parent().parent()).getId();
-                shardId = ((RedisMeta) instanceNode).parent().getId();
+                try {
+                    RedisMeta redisMeta = (RedisMeta) instanceNode;
+                    String clusterId = ((ClusterMeta) redisMeta.parent().parent()).getId();
+                    String shardId = redisMeta.parent().getId();
+                    List<Pair<String, Integer>> single = new ArrayList<>();
+                    single.add(new Pair<>(instanceNode.getIp(), instanceNode.getPort()));
+
+                    Long azId = null;
+                    if (azService != null && redisMeta.getAz() != null) {
+                        try {
+                            azId = azService.getAvailableZoneTblByAzName(redisMeta.getAz()).getId();
+                        } catch (Exception e) {
+                            logger.warn("[RedisMetaSynchronizer][add] failed to get azId for az {}", redisMeta.getAz(), e);
+                        }
+                    }
+
+                    logger.info("[RedisMetaSynchronizer][insertRedises]{}", instanceNode);
+                    redisService.insertRedises(dcId, clusterId, shardId, single, azId);
+                } catch (Exception e) {
+                    logger.error("[RedisMetaSynchronizer][insertRedises]{}", instanceNode, e);
+                }
             }
-            logger.info("[RedisMetaSynchronizer][insertRedises]{}", added);
-            redisService.insertRedises(dcId, clusterId, shardId, toAdded);
-            CatEventMonitor.DEFAULT.logEvent(META_SYNC, String.format("[addRedises]%s", toAdded));
+            CatEventMonitor.DEFAULT.logEvent(META_SYNC, String.format("[addRedises]%s", added));
         } catch (Exception e) {
             logger.error("[RedisMetaSynchronizer][insertRedises]", e);
         }

--- a/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/resources/ShardMetaSynchronizer.java
+++ b/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/resources/ShardMetaSynchronizer.java
@@ -5,6 +5,7 @@ import com.ctrip.xpipe.monitor.CatEventMonitor;
 import com.ctrip.xpipe.redis.console.config.ConsoleConfig;
 import com.ctrip.xpipe.redis.console.model.ShardTbl;
 import com.ctrip.xpipe.redis.console.sentinel.SentinelBalanceService;
+import com.ctrip.xpipe.redis.console.service.AzService;
 import com.ctrip.xpipe.redis.console.service.RedisService;
 import com.ctrip.xpipe.redis.console.service.ShardService;
 import com.ctrip.xpipe.redis.core.entity.ClusterMeta;
@@ -26,6 +27,7 @@ public class ShardMetaSynchronizer implements MetaSynchronizer {
     private Set<ShardMeta> removed;
     private Set<MetaComparator> modified;
     private RedisService redisService;
+    private AzService azService;
     private ShardService shardService;
     private SentinelBalanceService sentinelBalanceService;
     private ConsoleConfig consoleConfig;
@@ -34,12 +36,13 @@ public class ShardMetaSynchronizer implements MetaSynchronizer {
     public ShardMetaSynchronizer(Set<ShardMeta> added, Set<ShardMeta> removed, Set<MetaComparator> modified,
                                  RedisService redisService, ShardService shardService,
                                  SentinelBalanceService sentinelBalanceService, ConsoleConfig consoleConfig,
-                                 String dcId
+                                 AzService azService, String dcId
     ) {
         this.added = added;
         this.removed = removed;
         this.modified = modified;
         this.redisService = redisService;
+        this.azService = azService;
         this.shardService = shardService;
         this.sentinelBalanceService = sentinelBalanceService;
         this.consoleConfig = consoleConfig;
@@ -84,7 +87,7 @@ public class ShardMetaSynchronizer implements MetaSynchronizer {
                         }
 
                         CatEventMonitor.DEFAULT.logEvent(META_SYNC, String.format("[addShard]%s", shardMeta.getId()));
-                        new RedisMetaSynchronizer(Sets.newHashSet(shardMeta.getRedises()), null, null, redisService, dcId).sync();
+                        new RedisMetaSynchronizer(Sets.newHashSet(shardMeta.getRedises()), null, null, redisService, azService, dcId).sync();
                     } catch (Exception e) {
                         logger.error("[ShardMetaSynchronizer][findOrCreateShardIfNotExist]{}", shardMeta, e);
                     }
@@ -102,7 +105,7 @@ public class ShardMetaSynchronizer implements MetaSynchronizer {
                     try {
                         logger.info("[ShardMetaSynchronizer][update]{} -> {}", shardMetaComparator.getCurrent(), shardMetaComparator.getFuture());
                         new RedisMetaSynchronizer(shardMetaComparator.getAdded(), shardMetaComparator.getRemoved(),
-                                shardMetaComparator.getMofified(), redisService, dcId).sync();
+                                shardMetaComparator.getMofified(), redisService, azService, dcId).sync();
                     } catch (Exception e) {
                         logger.error("[ShardMetaSynchronizer][update]{} -> {}", ((ShardMetaComparator) metaComparator).getCurrent(), ((ShardMetaComparator) metaComparator).getFuture(), e);
                     }

--- a/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/service/RedisService.java
+++ b/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/service/RedisService.java
@@ -30,6 +30,7 @@ public interface RedisService {
 	List<RedisTbl> findKeepersByDcClusterShard(String dcId, String clusterId, String shardId) throws ResourceNotFoundException;
 
 	void insertRedises(String dcId, String clusterId, String shardId, List<Pair<String, Integer>> addrs) throws DalException, ResourceNotFoundException;
+	void insertRedises(String dcId, String clusterId, String shardId, List<Pair<String, Integer>> addrs, Long azId) throws DalException, ResourceNotFoundException;
 	void deleteRedises(String dcId, String clusterId, String shardId, List<Pair<String, Integer>> addrs) throws ResourceNotFoundException;
 
 	int insertKeepers(String dcId, String clusterId, String shardId, List<KeeperBasicInfo> keepers) throws DalException, ResourceNotFoundException;

--- a/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/service/impl/RedisServiceImpl.java
+++ b/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/service/impl/RedisServiceImpl.java
@@ -194,6 +194,16 @@ public class RedisServiceImpl extends AbstractConsoleService<RedisTblDao> implem
     }
 
     @Override
+    public synchronized void insertRedises(String dcId, String clusterId, String shardId,
+                                           List<Pair<String, Integer>> redisAddresses, Long azId)
+            throws DalException, ResourceNotFoundException {
+
+        doInsertInstances(XPipeConsoleConstant.ROLE_REDIS, dcId, clusterId, shardId, redisAddresses, azId);
+
+        notifyClusterUpdate(dcId, clusterId);
+    }
+
+    @Override
     public synchronized int insertKeepers(String dcId, String clusterId, String shardId,
                                           List<KeeperBasicInfo> keepers) throws DalException, ResourceNotFoundException {
 
@@ -239,6 +249,10 @@ public class RedisServiceImpl extends AbstractConsoleService<RedisTblDao> implem
 
 
     private void doInsertInstances(String role, String dcId, String clusterId, String shardId, List<Pair<String, Integer>> redisAddresses) throws ResourceNotFoundException, DalException {
+        doInsertInstances(role, dcId, clusterId, shardId, redisAddresses, null);
+    }
+
+    private void doInsertInstances(String role, String dcId, String clusterId, String shardId, List<Pair<String, Integer>> redisAddresses, Long azId) throws ResourceNotFoundException, DalException {
 
         DcClusterShardTbl dcClusterShardTbl = dcClusterShardService.find(dcId, clusterId, shardId);
         if (dcClusterShardTbl == null) {
@@ -250,7 +264,7 @@ public class RedisServiceImpl extends AbstractConsoleService<RedisTblDao> implem
 
         logger.info("[doInsertInstances]{}", toAdd);
 
-        insertInstancesToDb(dcClusterShardTbl.getDcClusterShardId(), role, toAdd.toArray(new Pair[0]));
+        insertInstancesToDb(dcClusterShardTbl.getDcClusterShardId(), role, azId, toAdd.toArray(new Pair[0]));
     }
 
     @Override
@@ -595,6 +609,18 @@ public class RedisServiceImpl extends AbstractConsoleService<RedisTblDao> implem
 
         for (Pair<String, Integer> addr : addrs) {
             insert(createRedisTbl(addr, role).setDcClusterShardId(dcClusterShardId));
+        }
+
+    }
+
+    public void insertInstancesToDb(long dcClusterShardId, String role, Long azId, Pair<String, Integer>... addrs) throws DalException {
+
+        for (Pair<String, Integer> addr : addrs) {
+            RedisTbl redisTbl = createRedisTbl(addr, role).setDcClusterShardId(dcClusterShardId);
+            if (azId != null && azId > 0) {
+                redisTbl.setAzId(azId);
+            }
+            insert(redisTbl);
         }
 
     }

--- a/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/service/impl/RedisServiceWithoutDB.java
+++ b/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/service/impl/RedisServiceWithoutDB.java
@@ -81,6 +81,11 @@ public class RedisServiceWithoutDB implements RedisService {
     }
 
     @Override
+    public void insertRedises(String dcId, String clusterId, String shardId, List<Pair<String, Integer>> addrs, Long azId) throws DalException, ResourceNotFoundException {
+        consolePortalService.insertRedises(dcId, clusterId, shardId, addrs, azId);
+    }
+
+    @Override
     public void deleteRedises(String dcId, String clusterId, String shardId, List<Pair<String, Integer>> addrs) throws ResourceNotFoundException {
         throw new UnsupportedOperationException();
     }

--- a/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/service/meta/impl/BeaconMetaServiceImpl.java
+++ b/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/service/meta/impl/BeaconMetaServiceImpl.java
@@ -86,7 +86,9 @@ public class BeaconMetaServiceImpl implements BeaconMetaService {
             ShardMeta shardMeta = entry.getValue();
             List<MonitorGroupMeta> groups = shardMeta.getRedises().stream().map(redisMeta -> {
                 HostPort hostPort = new HostPort(redisMeta.getIp(), redisMeta.getPort());
-                return new MonitorGroupMeta(hostPort.toString(), dc, Collections.singleton(hostPort), redisMeta.isMaster());
+                MonitorGroupMeta group = new MonitorGroupMeta(hostPort.toString(), dc, Collections.singleton(hostPort), redisMeta.isMaster());
+                group.setAz(redisMeta.getAz());
+                return group;
             }).collect(Collectors.toList());
             shards.add(new MonitorShardMeta(shardName, groups));
         }

--- a/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/service/meta/impl/RedisMetaServiceImpl.java
+++ b/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/service/meta/impl/RedisMetaServiceImpl.java
@@ -5,6 +5,7 @@ import com.ctrip.xpipe.redis.checker.spring.DisableDbMode;
 import com.ctrip.xpipe.redis.console.constant.XPipeConsoleConstant;
 import com.ctrip.xpipe.redis.console.dao.RedisDao;
 import com.ctrip.xpipe.redis.console.model.RedisTbl;
+import com.ctrip.xpipe.redis.console.service.AzService;
 import com.ctrip.xpipe.redis.console.service.RedisService;
 import com.ctrip.xpipe.redis.console.service.exception.ResourceNotFoundException;
 import com.ctrip.xpipe.redis.console.service.meta.AbstractMetaService;
@@ -16,6 +17,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
@@ -29,9 +32,14 @@ import java.util.List;
 @DisableDbMode(false)
 public class RedisMetaServiceImpl extends AbstractMetaService implements RedisMetaService {
 	public static long REDIS_MASTER_NULL = 0L;
+
+	private static final Logger logger = LoggerFactory.getLogger(RedisMetaServiceImpl.class);
 	
 	@Autowired
 	private RedisService redisService;
+
+	@Autowired
+	private AzService azService;
 
 	@Override
 	public RedisMeta getRedisMeta(ShardMeta shardMeta, RedisTbl redisInfo) {
@@ -45,6 +53,13 @@ public class RedisMetaServiceImpl extends AbstractMetaService implements RedisMe
 				redisMeta.setMaster("");
 			} else {
 				redisMeta.setMaster(XPipeConsoleConstant.DEFAULT_ADDRESS);
+			}
+			if (redisInfo.getAzId() != null && redisInfo.getAzId() > 0) {
+				try {
+					redisMeta.setAz(azService.getAvailableZoneTblById(redisInfo.getAzId()).getAzName());
+				} catch (Exception e) {
+					logger.warn("[getRedisMeta] failed to get az name for azId {}", redisInfo.getAzId(), e);
+				}
 			}
 		}
 		

--- a/redis/redis-console/src/main/resources/META-INF/dal/jdbc/meta-dal.xml
+++ b/redis/redis-console/src/main/resources/META-INF/dal/jdbc/meta-dal.xml
@@ -1093,6 +1093,7 @@
 		<!-- RedisService.updateRedis() will fail, due to h2 db not recognize sequential insert with id of 0 -->
 		<member name="id" field="id" value-type="Long" length="20" nullable="true" key="true" auto-increment="true" />
 		<member name="count" value-type="long" select-expr="COUNT(rt.id) count" all="false"/>
+		<member name="az-id" field="az_id" value-type="Long" />
 		<var name="key-id" value-type="Long" key-member="id" />
 
 		<var name="dc-name" value-type="String"/>

--- a/redis/redis-console/src/test/java/com/ctrip/xpipe/redis/console/resources/DcMetaSynchronizerTest.java
+++ b/redis/redis-console/src/test/java/com/ctrip/xpipe/redis/console/resources/DcMetaSynchronizerTest.java
@@ -69,16 +69,20 @@ public class DcMetaSynchronizerTest {
     @Mock
     private ClusterTypeUpdateEventFactory clusterTypeUpdateEventFactory;
 
+    @Mock
+    private AzService azService;
+
     private String singleDcCacheCluster = "SingleDcCacheCluster";
     private String localDcCacheCluster = "LocalDcCacheCluster";
 
     private String dcId = FoundationService.DEFAULT.getDataCenter();
 
     @Before
-    public void beforeDcMetaSynchronizerTest() {
+    public void
+            () {
         dcMetaSynchronizer = new DcMetaSynchronizer(consoleConfig, metaCache, redisService, shardService,
                 clusterService, dcService, organizationService, sentinelBalanceService,
-                clusterTypeUpdateEventFactory, outerClientService, dcId);
+                clusterTypeUpdateEventFactory, outerClientService, azService, dcId);
     }
 
     @Test

--- a/redis/redis-core/src/main/resources/META-INF/dal/model/keeper-model.xml
+++ b/redis/redis-core/src/main/resources/META-INF/dal/model/keeper-model.xml
@@ -93,6 +93,7 @@
 	<entity name="redis" implements="java.io.Serializable, com.ctrip.xpipe.redis.core.entity.Redis">
 		<attribute name="offset" value-type="Long" />
 		<attribute name="gid" value-type="Long" />
+		<attribute name="az" value-type="String" />
 		<snippet>
 			public boolean isMaster(){
 			return m_master == null || m_master.trim().length() == 0;


### PR DESCRIPTION
## 背景
  Beacon SENTINEL 模式支持按 AZ 偏好切换 master，前提是每个节点注册为独立 group 并携带 az tag。此前 XPipe 注册集群时未传 az 字段，导致该能力完全失效。

  ## 改动
  **数据模型**
  - `keeper-model.xml` 新增 az 属性，重新生成 `RedisMeta`
  - `meta-dal.xml` 新增 az-id 字段，重新生成 `RedisTbl`
  - `MonitorGroupMeta` 新增 az 字段，更新 equals/hashCode

  **DB → 内存实体**   
  - `RedisMetaServiceImpl`：组装 `RedisMeta` 时通过 `AzService` 将 azId 转换为 az 名称

  **内存实体 → Beacon 注册数据**
  - `BeaconMetaServiceImpl`：构造 SENTINEL shard 时将 az 写入每个 group

  **Hash 一致性**
  - `MonitorClusterMeta`：hash 计算加入 az，group 复制时保留 az

  **手动 API 路径**
  - `RedisCreateInfo` 新增 azId 字段
  - `RedisService` / `RedisServiceImpl` 新增带 azId 的 insertRedises 重载，消除 doInsertInstances 重复代码
  - `ConsolePortalService` 新增带 azId 的重载，RedisServiceWithoutDB 透传 azId

  **Credis 同步路径**
  - `OuterClientService.RedisMeta` 新增 az 字段，Credis 返回后 Jackson 自动填入
  - `DcMetaSynchronizer`：outerRedisToInner 和 newRedis 透传 az
  - `RedisMetaSynchronizer`：改为逐节点处理，支持每个节点独立查询 azId
  - `AzService` 通过构造函数逐层透传：MetaSynchronizer → DcMetaSynchronizer → ClusterMetaSynchronizer → ShardMetaSynchronizer → RedisMetaSynchronizer

  ## 兼容性
  - az 为 null 时不影响现有功能，存量数据不受影响
  - Credis 侧暂未返回 az 字段，XPipe 侧已就绪，Credis 加字段后自动生效