### PR TITLE
[delay-metric-is-new] Tag delay metric with isNew for newly created R…

### DIFF
--- a/redis/dockerPackage/xpipe-console/sql/xpipedemodbtables.sql
+++ b/redis/dockerPackage/xpipe-console/sql/xpipedemodbtables.sql
@@ -168,6 +168,7 @@ CREATE TABLE `REDIS_TBL` (
   `redis_master` bigint(20) unsigned DEFAULT NULL COMMENT 'redis master id',
   `keepercontainer_id` bigint(20) unsigned DEFAULT NULL COMMENT 'keepercontainer id',
   `DataChange_LastTime` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'last modified time',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'instance create time',
   `deleted` tinyint(1) NOT NULL DEFAULT '0' COMMENT 'deleted or not',
   `deleted_at` int(11) NOT NULL DEFAULT '0' COMMENT 'deleted time',
   PRIMARY KEY (`id`),

--- a/redis/redis-checker/src/main/java/com/ctrip/xpipe/redis/checker/config/impl/CommonConfigBean.java
+++ b/redis/redis-checker/src/main/java/com/ctrip/xpipe/redis/checker/config/impl/CommonConfigBean.java
@@ -53,6 +53,14 @@ public class CommonConfigBean extends AbstractConfigBean {
 
     public static final String KEY_NO_ALARM_MUNITE_FOR_CLUSTER_UPDATE = "no.alarm.minute.for.cluster.update";
 
+    public static final String KEY_DELAY_METRIC_NEW_INSTANCE_MINUTES = "delay.metric.new.instance.minutes";
+
+    private static final int DEFAULT_DELAY_METRIC_NEW_INSTANCE_MINUTES = 15;
+
+    private static final int MIN_DELAY_METRIC_NEW_INSTANCE_MINUTES = 1;
+
+    private static final int MAX_DELAY_METRIC_NEW_INSTANCE_MINUTES = 24 * 60;
+
     public static final String KEY_META_SYNC_EXTERNAL_DC = "meta.sync.external.dc";
 
     public static final String KEY_KEEPERCONTAINER_DISK_INFO_COLLECT_INTERVAL_MILLS = "keeper.disk.info.collect.interval";
@@ -155,6 +163,21 @@ public class CommonConfigBean extends AbstractConfigBean {
 
     public int getNoAlarmMinutesForClusterUpdate() {
         return getIntProperty(KEY_NO_ALARM_MUNITE_FOR_CLUSTER_UPDATE, 15);
+    }
+
+    public int getDelayMetricNewInstanceMinutes() {
+        int minutes = getIntProperty(KEY_DELAY_METRIC_NEW_INSTANCE_MINUTES, DEFAULT_DELAY_METRIC_NEW_INSTANCE_MINUTES);
+        if (minutes < MIN_DELAY_METRIC_NEW_INSTANCE_MINUTES) {
+            logger.warn("[getDelayMetricNewInstanceMinutes] invalid value {}, use {}", minutes,
+                    MIN_DELAY_METRIC_NEW_INSTANCE_MINUTES);
+            return MIN_DELAY_METRIC_NEW_INSTANCE_MINUTES;
+        }
+        if (minutes > MAX_DELAY_METRIC_NEW_INSTANCE_MINUTES) {
+            logger.warn("[getDelayMetricNewInstanceMinutes] invalid value {}, use {}", minutes,
+                    MAX_DELAY_METRIC_NEW_INSTANCE_MINUTES);
+            return MAX_DELAY_METRIC_NEW_INSTANCE_MINUTES;
+        }
+        return minutes;
     }
 
     public boolean getCheckBeaconLastModify() {

--- a/redis/redis-checker/src/main/java/com/ctrip/xpipe/redis/checker/healthcheck/RedisInstanceInfo.java
+++ b/redis/redis-checker/src/main/java/com/ctrip/xpipe/redis/checker/healthcheck/RedisInstanceInfo.java
@@ -3,6 +3,7 @@ package com.ctrip.xpipe.redis.checker.healthcheck;
 import com.ctrip.xpipe.endpoint.ClusterShardHostPort;
 import com.ctrip.xpipe.endpoint.HostPort;
 
+import java.util.Date;
 import java.util.Map;
 
 /**
@@ -33,5 +34,7 @@ public interface RedisInstanceInfo extends CheckInfo {
     Long getShardDbId();
 
     Map<Long, String> getActiveDcAllShardIds();
+
+    Date getCreateTime();
 
 }

--- a/redis/redis-checker/src/main/java/com/ctrip/xpipe/redis/checker/healthcheck/actions/delay/DelayActionContext.java
+++ b/redis/redis-checker/src/main/java/com/ctrip/xpipe/redis/checker/healthcheck/actions/delay/DelayActionContext.java
@@ -14,8 +14,4 @@ public class DelayActionContext extends AbstractActionContext<Long, RedisHealthC
         super(instance, delay);
     }
 
-    public String getDelayType() {
-        return "default";
-    }
-
 }

--- a/redis/redis-checker/src/main/java/com/ctrip/xpipe/redis/checker/healthcheck/actions/delay/HeteroDelayActionContext.java
+++ b/redis/redis-checker/src/main/java/com/ctrip/xpipe/redis/checker/healthcheck/actions/delay/HeteroDelayActionContext.java
@@ -17,10 +17,6 @@ public class HeteroDelayActionContext extends DelayActionContext {
         return shardDbId;
     }
 
-    public String getDelayType() {
-        return "hetero";
-    }
-
     public boolean isExpired() {
         return isExpired;
     }

--- a/redis/redis-checker/src/main/java/com/ctrip/xpipe/redis/checker/healthcheck/actions/delay/MetricDelayListener.java
+++ b/redis/redis-checker/src/main/java/com/ctrip/xpipe/redis/checker/healthcheck/actions/delay/MetricDelayListener.java
@@ -3,12 +3,15 @@ package com.ctrip.xpipe.redis.checker.healthcheck.actions.delay;
 import com.ctrip.xpipe.api.foundation.FoundationService;
 import com.ctrip.xpipe.metric.MetricData;
 import com.ctrip.xpipe.metric.MetricProxy;
+import com.ctrip.xpipe.redis.checker.config.impl.CommonConfigBean;
 import com.ctrip.xpipe.redis.checker.healthcheck.*;
 import com.ctrip.xpipe.utils.ServicesUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import java.util.Date;
 
 
 /**
@@ -25,8 +28,17 @@ public class MetricDelayListener extends AbstractDelayActionListener implements 
 
     private static final double THOUSAND = 1000.0;
 
+    private static final long MILLIS_PER_MINUTE = 60_000L;
+
+    private static final String TAG_IS_NEW_YES = "1";
+
+    private static final String TAG_IS_NEW_NO = "0";
+
     @Autowired
     private FoundationService foundationService;
+
+    @Autowired
+    private CommonConfigBean commonConfigBean;
 
     private MetricProxy proxy = ServicesUtil.getMetricProxy();
 
@@ -39,7 +51,11 @@ public class MetricDelayListener extends AbstractDelayActionListener implements 
         data.setHostPort(info.getHostPort());
 
         data.setClusterType(info.getClusterType());
-        data.addTag("delayType", context.getDelayType());
+        Date createTime = info.getCreateTime();
+        int minutes = commonConfigBean.getDelayMetricNewInstanceMinutes();
+        long recvTime = context.getRecvTimeMilli();
+        boolean isNew = isNewInstance(createTime, recvTime, minutes);
+        data.addTag("isNew", isNew ? TAG_IS_NEW_YES : TAG_IS_NEW_NO);
         data.addTag("crossDc", String.valueOf(!foundationService.getDataCenter().equalsIgnoreCase(info.getDcId())));
         data.addTag("crossRegion", String.valueOf(info.isCrossRegion()));
         if (context instanceof HeteroDelayActionContext) {
@@ -48,6 +64,13 @@ public class MetricDelayListener extends AbstractDelayActionListener implements 
             data.addTag("srcShardId", "-");
         }
         return data;
+    }
+
+    static boolean isNewInstance(Date createTime, long recvTimeMilli, int windowMinutes) {
+        if (createTime == null) {
+            return false;
+        }
+        return recvTimeMilli < createTime.getTime() + windowMinutes * MILLIS_PER_MINUTE;
     }
 
     @Override

--- a/redis/redis-checker/src/main/java/com/ctrip/xpipe/redis/checker/healthcheck/impl/DefaultHealthCheckInstanceFactory.java
+++ b/redis/redis-checker/src/main/java/com/ctrip/xpipe/redis/checker/healthcheck/impl/DefaultHealthCheckInstanceFactory.java
@@ -140,6 +140,9 @@ public class DefaultHealthCheckInstanceFactory implements HealthCheckInstanceFac
         Integer orgId = clusterMeta.getOrgId();
         info.setClusterOrgId(orgId == null ? -1 : orgId);
         info.isMaster(redisMeta.isMaster());
+        if (redisMeta.getCreateTime() != null) {
+            info.setCreateTime(new Date(redisMeta.getCreateTime()));
+        }
         info.setAzGroupType(clusterMeta.getAzGroupType());
         info.setAsymmetricCluster(metaCache.isAsymmetricCluster(info.getClusterId()));
         if (clusterType.supportSingleActiveDC()) {

--- a/redis/redis-checker/src/main/java/com/ctrip/xpipe/redis/checker/healthcheck/impl/DefaultRedisInstanceInfo.java
+++ b/redis/redis-checker/src/main/java/com/ctrip/xpipe/redis/checker/healthcheck/impl/DefaultRedisInstanceInfo.java
@@ -13,6 +13,7 @@ import com.google.common.collect.Maps;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Date;
 
 /**
  * @author chen.zhu
@@ -34,6 +35,8 @@ public class DefaultRedisInstanceInfo extends AbstractCheckInfo implements Redis
     private Long shardDbId;
 
     private Map<Long, String> activeDcShardIds = new HashMap<>();
+
+    private Date createTime;
 
     public DefaultRedisInstanceInfo() {
         super();
@@ -106,6 +109,11 @@ public class DefaultRedisInstanceInfo extends AbstractCheckInfo implements Redis
     }
 
     @Override
+    public Date getCreateTime() {
+        return createTime;
+    }
+
+    @Override
     public String toString() {
         return StringUtil.join(", ", dcId, clusterId, shardId, hostPort, isMaster ? "Master" : "Slave",
             "activeDc:" + activeDc, clusterType, crossRegion ? "proxied" : "normal", "azGroupType:" + azGroupType,
@@ -144,6 +152,10 @@ public class DefaultRedisInstanceInfo extends AbstractCheckInfo implements Redis
 
     public void setActiveDcShardIds(Map<Long, String> shardIds) {
         this.activeDcShardIds = shardIds;
+    }
+
+    public void setCreateTime(Date createTime) {
+        this.createTime = createTime;
     }
 
     @VisibleForTesting

--- a/redis/redis-checker/src/test/java/com/ctrip/xpipe/redis/checker/AllTests.java
+++ b/redis/redis-checker/src/test/java/com/ctrip/xpipe/redis/checker/AllTests.java
@@ -10,6 +10,7 @@ import com.ctrip.xpipe.redis.checker.alert.manager.AlertPolicyManagerTest;
 import com.ctrip.xpipe.redis.checker.alert.message.holder.DefaultAlertEntityHolderTest;
 import com.ctrip.xpipe.redis.checker.alert.message.subscriber.AlertEntityDelaySubscriberTest;
 import com.ctrip.xpipe.redis.checker.alert.message.subscriber.AlertRecoverySubscriberTest;
+import com.ctrip.xpipe.redis.checker.config.impl.CommonConfigBeanTest;
 import com.ctrip.xpipe.redis.checker.config.impl.DefaultCheckerDbConfigTest;
 import com.ctrip.xpipe.redis.checker.controller.CheckerHealthControllerTest;
 import com.ctrip.xpipe.redis.checker.controller.result.ActionContextRetMessageTest;
@@ -17,6 +18,7 @@ import com.ctrip.xpipe.redis.checker.healthcheck.actions.crdtredisconf.CRDTRedis
 import com.ctrip.xpipe.redis.checker.healthcheck.actions.crdtredisconf.CRDTRedisConfigCheckRuleActionTest;
 import com.ctrip.xpipe.redis.checker.healthcheck.actions.delay.CRDTDelayActionControllerTest;
 import com.ctrip.xpipe.redis.checker.healthcheck.actions.delay.DelayActionTest;
+import com.ctrip.xpipe.redis.checker.healthcheck.actions.delay.MetricDelayListenerTest;
 import com.ctrip.xpipe.redis.checker.healthcheck.actions.gtidgap.GtidGapCheckActionControllerTest;
 import com.ctrip.xpipe.redis.checker.healthcheck.actions.gtidgap.GtidGapCheckActionTest;
 import com.ctrip.xpipe.redis.checker.healthcheck.actions.interaction.*;
@@ -94,6 +96,7 @@ import org.junit.runners.Suite;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses(value = {
+        CommonConfigBeanTest.class,
         DefaultCheckerDbConfigTest.class,
 
         DefaultSentinelHelloCollectorTest.class,
@@ -128,6 +131,7 @@ import org.junit.runners.Suite;
         DefaultAlertEntityHolderTest.class,
         DefaultDcMetaChangeManagerTest.class,
         DelayActionTest.class,
+        MetricDelayListenerTest.class,
         CRDTDelayActionControllerTest.class,
         CurrentDcSentinelHelloCollectorTest.class,
         InfoReplicationActionTest.class,

--- a/redis/redis-checker/src/test/java/com/ctrip/xpipe/redis/checker/config/impl/CommonConfigBeanTest.java
+++ b/redis/redis-checker/src/test/java/com/ctrip/xpipe/redis/checker/config/impl/CommonConfigBeanTest.java
@@ -1,0 +1,83 @@
+package com.ctrip.xpipe.redis.checker.config.impl;
+
+import com.ctrip.xpipe.api.config.Config;
+import com.ctrip.xpipe.api.config.ConfigChangeListener;
+import com.ctrip.xpipe.redis.core.AbstractRedisTest;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class CommonConfigBeanTest extends AbstractRedisTest {
+
+    private Map<String, String> properties;
+
+    private CommonConfigBean commonConfigBean;
+
+    @Before
+    public void setupCommonConfigBeanTest() {
+        properties = new HashMap<>();
+        commonConfigBean = new TestableCommonConfigBean();
+        ((TestableCommonConfigBean) commonConfigBean).useConfig(new Config() {
+            @Override
+            public String get(String key) {
+                return properties.get(key);
+            }
+
+            @Override
+            public String get(String key, String defaultValue) {
+                return properties.getOrDefault(key, defaultValue);
+            }
+
+            @Override
+            public void addConfigChangeListener(ConfigChangeListener configChangeListener) {
+            }
+
+            @Override
+            public void removeConfigChangeListener(ConfigChangeListener configChangeListener) {
+            }
+
+            @Override
+            public int getOrder() {
+                return 0;
+            }
+        });
+    }
+
+    @Test
+    public void testDelayMetricNewInstanceMinutesDefault() {
+        Assert.assertEquals(15, commonConfigBean.getDelayMetricNewInstanceMinutes());
+    }
+
+    @Test
+    public void testDelayMetricNewInstanceMinutesValidValue() {
+        properties.put(CommonConfigBean.KEY_DELAY_METRIC_NEW_INSTANCE_MINUTES, "30");
+        Assert.assertEquals(30, commonConfigBean.getDelayMetricNewInstanceMinutes());
+    }
+
+    @Test
+    public void testDelayMetricNewInstanceMinutesClampZero() {
+        properties.put(CommonConfigBean.KEY_DELAY_METRIC_NEW_INSTANCE_MINUTES, "0");
+        Assert.assertEquals(1, commonConfigBean.getDelayMetricNewInstanceMinutes());
+    }
+
+    @Test
+    public void testDelayMetricNewInstanceMinutesClampNegative() {
+        properties.put(CommonConfigBean.KEY_DELAY_METRIC_NEW_INSTANCE_MINUTES, "-5");
+        Assert.assertEquals(1, commonConfigBean.getDelayMetricNewInstanceMinutes());
+    }
+
+    @Test
+    public void testDelayMetricNewInstanceMinutesClampTooLarge() {
+        properties.put(CommonConfigBean.KEY_DELAY_METRIC_NEW_INSTANCE_MINUTES, "100000");
+        Assert.assertEquals(24 * 60, commonConfigBean.getDelayMetricNewInstanceMinutes());
+    }
+
+    private static class TestableCommonConfigBean extends CommonConfigBean {
+        void useConfig(Config config) {
+            setConfig(config);
+        }
+    }
+}

--- a/redis/redis-checker/src/test/java/com/ctrip/xpipe/redis/checker/healthcheck/actions/delay/MetricDelayListenerTest.java
+++ b/redis/redis-checker/src/test/java/com/ctrip/xpipe/redis/checker/healthcheck/actions/delay/MetricDelayListenerTest.java
@@ -1,0 +1,148 @@
+package com.ctrip.xpipe.redis.checker.healthcheck.actions.delay;
+
+import com.ctrip.xpipe.api.foundation.FoundationService;
+import com.ctrip.xpipe.cluster.ClusterType;
+import com.ctrip.xpipe.metric.MetricData;
+import com.ctrip.xpipe.metric.MetricProxy;
+import com.ctrip.xpipe.redis.checker.AbstractCheckerTest;
+import com.ctrip.xpipe.redis.checker.config.impl.CommonConfigBean;
+import com.ctrip.xpipe.redis.checker.healthcheck.RedisHealthCheckInstance;
+import com.ctrip.xpipe.redis.checker.healthcheck.impl.DefaultRedisInstanceInfo;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Date;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class MetricDelayListenerTest extends AbstractCheckerTest {
+
+    private static final int WINDOW_MINUTES = 15;
+
+    private static final long MILLIS_PER_MINUTE = 60_000L;
+
+    private MetricDelayListener listener;
+
+    private MetricProxy proxy;
+
+    private CommonConfigBean commonConfigBean;
+
+    private RedisHealthCheckInstance instance;
+
+    private AtomicReference<MetricData> capturedPoint;
+
+    @Before
+    public void setupMetricDelayListenerTest() throws Exception {
+        listener = new MetricDelayListener();
+        proxy = Mockito.mock(MetricProxy.class);
+        commonConfigBean = Mockito.mock(CommonConfigBean.class);
+        capturedPoint = new AtomicReference<>();
+
+        ReflectionTestUtils.setField(listener, "proxy", proxy);
+        ReflectionTestUtils.setField(listener, "commonConfigBean", commonConfigBean);
+        ReflectionTestUtils.setField(listener, "foundationService", FoundationService.DEFAULT);
+
+        Mockito.when(commonConfigBean.getDelayMetricNewInstanceMinutes()).thenReturn(WINDOW_MINUTES);
+
+        Mockito.doAnswer(invocation -> {
+            capturedPoint.set(invocation.getArgument(0, MetricData.class));
+            return null;
+        }).when(proxy).writeBinMultiDataPoint(Mockito.any());
+
+        instance = newRandomRedisHealthCheckInstance(FoundationService.DEFAULT.getDataCenter(), ClusterType.ONE_WAY, randomPort());
+    }
+
+    @Test
+    public void testIsNewWithinWindow() throws Exception {
+        setCreateTime(new Date());
+
+        listener.onAction(new DelayActionContext(instance, 1000L));
+
+        Assert.assertEquals("1", capturedPoint.get().getTags().get("isNew"));
+        Assert.assertNull(capturedPoint.get().getTags().get("delayType"));
+    }
+
+    @Test
+    public void testIsNewOutsideWindow() throws Exception {
+        long recvTime = System.currentTimeMillis();
+        setCreateTime(new Date(recvTime - 20 * MILLIS_PER_MINUTE));
+
+        listener.onAction(contextWithRecvTime(recvTime));
+
+        Assert.assertEquals("0", capturedPoint.get().getTags().get("isNew"));
+        Assert.assertNull(capturedPoint.get().getTags().get("delayType"));
+    }
+
+    @Test
+    public void testIsNewWhenCreateTimeNull() throws Exception {
+        setCreateTime(null);
+
+        listener.onAction(new DelayActionContext(instance, 1000L));
+
+        Assert.assertEquals("0", capturedPoint.get().getTags().get("isNew"));
+        Assert.assertNull(capturedPoint.get().getTags().get("delayType"));
+    }
+
+    @Test
+    public void testIsNewEpochZero() throws Exception {
+        long recvTime = System.currentTimeMillis();
+        setCreateTime(new Date(0L));
+
+        listener.onAction(contextWithRecvTime(recvTime));
+
+        Assert.assertEquals("0", capturedPoint.get().getTags().get("isNew"));
+    }
+
+    @Test
+    public void testIsNewAtWindowBoundary() throws Exception {
+        long recvTime = System.currentTimeMillis();
+        setCreateTime(new Date(recvTime - WINDOW_MINUTES * MILLIS_PER_MINUTE));
+
+        listener.onAction(contextWithRecvTime(recvTime));
+
+        Assert.assertEquals("0", capturedPoint.get().getTags().get("isNew"));
+    }
+
+    @Test
+    public void testIsNewJustInsideWindow() throws Exception {
+        long recvTime = System.currentTimeMillis();
+        setCreateTime(new Date(recvTime - WINDOW_MINUTES * MILLIS_PER_MINUTE + 1));
+
+        listener.onAction(contextWithRecvTime(recvTime));
+
+        Assert.assertEquals("1", capturedPoint.get().getTags().get("isNew"));
+    }
+
+    @Test
+    public void testIsNewFutureCreateTime() throws Exception {
+        long recvTime = System.currentTimeMillis();
+        setCreateTime(new Date(recvTime + MILLIS_PER_MINUTE));
+
+        listener.onAction(contextWithRecvTime(recvTime));
+
+        Assert.assertEquals("1", capturedPoint.get().getTags().get("isNew"));
+    }
+
+    @Test
+    public void testIsNewInstanceUnit() {
+        long recvTime = 1_000_000L;
+        Date createTime = new Date(recvTime - WINDOW_MINUTES * MILLIS_PER_MINUTE);
+
+        Assert.assertFalse(MetricDelayListener.isNewInstance(createTime, recvTime, WINDOW_MINUTES));
+        Assert.assertTrue(MetricDelayListener.isNewInstance(createTime, recvTime - 1, WINDOW_MINUTES));
+        Assert.assertFalse(MetricDelayListener.isNewInstance(null, recvTime, WINDOW_MINUTES));
+    }
+
+    private DelayActionContext contextWithRecvTime(long recvTimeMilli) {
+        DelayActionContext context = new DelayActionContext(instance, 1000L);
+        ReflectionTestUtils.setField(context, "recvTimeMilli", recvTimeMilli);
+        return context;
+    }
+
+    private void setCreateTime(Date createTime) {
+        DefaultRedisInstanceInfo info = (DefaultRedisInstanceInfo) instance.getCheckInfo();
+        info.setCreateTime(createTime);
+    }
+}

--- a/redis/redis-checker/src/test/java/com/ctrip/xpipe/redis/checker/healthcheck/factory/DefaultHealthCheckInstanceFactoryTest.java
+++ b/redis/redis-checker/src/test/java/com/ctrip/xpipe/redis/checker/healthcheck/factory/DefaultHealthCheckInstanceFactoryTest.java
@@ -68,6 +68,18 @@ public class DefaultHealthCheckInstanceFactoryTest extends AbstractCheckerIntegr
     }
 
     @Test
+    public void testCreateRedisInstanceInfoWithCreateTime() {
+        long createTimeMillis = System.currentTimeMillis();
+        RedisMeta redisMeta = normalRedisMeta().setCreateTime(createTimeMillis);
+        when(metaCache.getDc(new HostPort(redisMeta.getIp(), redisMeta.getPort()))).thenReturn("oy");
+
+        RedisHealthCheckInstance instance = factory.create(redisMeta);
+
+        Assert.assertEquals(new java.util.Date(createTimeMillis), instance.getCheckInfo().getCreateTime());
+        factory.remove(instance);
+    }
+
+    @Test
     public void testCreateProxyEnabledInstance() {
         XpipeMeta meta = new XpipeMeta();
         DcMeta local = newDcMeta(FoundationService.DEFAULT.getDataCenter());

--- a/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/build/ComponentsConfigurator.java
+++ b/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/build/ComponentsConfigurator.java
@@ -2,6 +2,8 @@ package com.ctrip.xpipe.redis.console.build;
 
 import com.ctrip.xpipe.redis.console.ds.*;
 import org.unidal.dal.jdbc.datasource.DataSourceProvider;
+import org.unidal.dal.jdbc.entity.DataObjectAccessor;
+import org.unidal.dal.jdbc.entity.DataObjectNaming;
 import org.unidal.lookup.configuration.AbstractResourceConfigurator;
 import org.unidal.lookup.configuration.Component;
 
@@ -27,6 +29,8 @@ public class ComponentsConfigurator extends AbstractResourceConfigurator {
                 .config(E("datasourceFile").value("datasources.xml"),
                         E("baseDirRef").value(KEY_XPIPE_LOCATION)));
         all.add(A(XPipeDataSource.class));
+        all.add(C(DataObjectAccessor.class, XPipeDataObjectAccessor.class)
+                .req(DataObjectNaming.class));
         return all;
     }
 

--- a/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/dao/RedisDao.java
+++ b/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/dao/RedisDao.java
@@ -13,6 +13,7 @@ import org.unidal.dal.jdbc.DalException;
 import org.unidal.lookup.ContainerLoader;
 
 import javax.annotation.PostConstruct;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -87,6 +88,9 @@ public class RedisDao extends AbstractXpipeConsoleDAO {
             Map<Long, String> cache = new HashMap<Long, String>();
             for (RedisTbl redis : redises) {
                 checkRedisNotExist(redis);
+                if (redis.getCreateTime() == null) {
+                    redis.setCreateTime(new Date());
+                }
                 if (redis.getRedisRole().equals(XPipeConsoleConstant.ROLE_KEEPER)) {
                     if (null == cache.get(redis.getDcClusterShardId())) {
                         String newKeeperId = getToCreateKeeperId(redis);
@@ -127,6 +131,9 @@ public class RedisDao extends AbstractXpipeConsoleDAO {
 
         if (redis.getRedisRole().equals(XPipeConsoleConstant.ROLE_KEEPER)) {
             redis.setRunId(getToCreateKeeperId(redis));
+        }
+        if (redis.getCreateTime() == null) {
+            redis.setCreateTime(new Date());
         }
         redisTblDao.insertBatch(redis);
         return redisTblDao.findWithBasicConfigurations(redis.getRunId(), redis.getDcClusterShardId(), redis.getRedisIp(), redis.getRedisPort(), RedisTblEntity.READSET_FULL);

--- a/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/ds/XPipeDataObjectAccessor.java
+++ b/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/ds/XPipeDataObjectAccessor.java
@@ -1,0 +1,29 @@
+package com.ctrip.xpipe.redis.console.ds;
+
+import org.unidal.dal.jdbc.entity.DefaultDataObjectAccessor;
+
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Date;
+
+/**
+ * Unidal DAL accessor that maps MySQL {@code DATETIME} columns to {@link Date}.
+ * MySQL Connector/J 8.0 returns {@link LocalDateTime} for DATETIME via {@code ResultSet.getObject()},
+ * which the default accessor does not convert.
+ */
+public class XPipeDataObjectAccessor extends DefaultDataObjectAccessor {
+
+    @Override
+    protected Object convert(Object value, Class<?> targetType) {
+        if (value != null && Date.class.isAssignableFrom(targetType)) {
+            if (value instanceof LocalDateTime) {
+                return Timestamp.valueOf((LocalDateTime) value);
+            }
+            if (value instanceof LocalDate) {
+                return java.sql.Date.valueOf((LocalDate) value);
+            }
+        }
+        return super.convert(value, targetType);
+    }
+}

--- a/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/service/meta/impl/RedisMetaServiceImpl.java
+++ b/redis/redis-console/src/main/java/com/ctrip/xpipe/redis/console/service/meta/impl/RedisMetaServiceImpl.java
@@ -50,6 +50,9 @@ public class RedisMetaServiceImpl extends AbstractMetaService implements RedisMe
 			redisMeta.setId(redisInfo.getRunId());
 			redisMeta.setIp(redisInfo.getRedisIp());
 			redisMeta.setPort(redisInfo.getRedisPort());
+			if (redisInfo.getCreateTime() != null) {
+				redisMeta.setCreateTime(redisInfo.getCreateTime().getTime());
+			}
 			if(redisInfo.isMaster()) {
 				redisMeta.setMaster("");
 			} else {

--- a/redis/redis-console/src/main/resources/META-INF/dal/jdbc/meta-codegen.xml
+++ b/redis/redis-console/src/main/resources/META-INF/dal/jdbc/meta-codegen.xml
@@ -296,6 +296,7 @@
     <member name="redis-master" field="redis_master" value-type="long" length="20" />
     <member name="keepercontainer-id" field="keepercontainer_id" value-type="long" length="20" />
     <member name="data-change-last-time" field="DataChange_LastTime" value-type="Date" nullable="false" />
+    <member name="create-time" field="create_time" value-type="Date" nullable="false" />
     <member name="deleted" field="deleted" value-type="boolean" nullable="false" />
     <member name="deleted-at" field="deleted_at" value-type="int" length="10" nullable="false" />
     <var name="key-id" value-type="long" key-member="id" />

--- a/redis/redis-console/src/main/resources/META-INF/dal/jdbc/meta-dal.xml
+++ b/redis/redis-console/src/main/resources/META-INF/dal/jdbc/meta-dal.xml
@@ -1129,6 +1129,7 @@
 				<member name="redis-master"/>
 				<member name="keepercontainer-id"/>
 				<member name="az-id"/>
+				<member name="create-time"/>
 			</readset>
 			<readset name="CONTAINER_ID">
 				<member name="keepercontainer-id" />

--- a/redis/redis-console/src/main/resources/META-INF/plexus/components-redis-console.xml
+++ b/redis/redis-console/src/main/resources/META-INF/plexus/components-redis-console.xml
@@ -465,5 +465,14 @@
 			<implementation>com.ctrip.xpipe.redis.console.ds.XPipeDataSource</implementation>
 			<instantiation-strategy>per-lookup</instantiation-strategy>
 		</component>
+		<component>
+			<role>org.unidal.dal.jdbc.entity.DataObjectAccessor</role>
+			<implementation>com.ctrip.xpipe.redis.console.ds.XPipeDataObjectAccessor</implementation>
+			<requirements>
+				<requirement>
+					<role>org.unidal.dal.jdbc.entity.DataObjectNaming</role>
+				</requirement>
+			</requirements>
+		</component>
 	</components>
 </plexus>

--- a/redis/redis-console/src/main/resources/sql/h2/xpipedemodbtables.sql
+++ b/redis/redis-console/src/main/resources/sql/h2/xpipedemodbtables.sql
@@ -178,6 +178,7 @@ create table REDIS_TBL
 	redis_master bigint unsigned default null,
 	keepercontainer_id bigint unsigned default null,
    	DataChange_LastTime timestamp default CURRENT_TIMESTAMP,
+	create_time datetime not null default CURRENT_TIMESTAMP,
 	deleted tinyint(1) not null default 0,
     deleted_at int not null default 0,
     az_id bigint(20) unsigned NOT NULL DEFAULT 0,

--- a/redis/redis-console/src/main/resources/sql/mysql/xpipedemodbtables.sql
+++ b/redis/redis-console/src/main/resources/sql/mysql/xpipedemodbtables.sql
@@ -209,6 +209,7 @@ CREATE TABLE `REDIS_TBL` (
   `keepercontainer_id` bigint(20) unsigned DEFAULT NULL COMMENT 'keepercontainer id',
   `az_id` bigint(20) unsigned NOT NULL DEFAULT '0' COMMENT 'available zone id',
   `DataChange_LastTime` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'last modified time',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'instance create time',
   `deleted` tinyint(1) NOT NULL DEFAULT '0' COMMENT 'deleted or not',
   `deleted_at` int(11) NOT NULL DEFAULT '0' COMMENT 'deleted time',
   PRIMARY KEY (`id`),

--- a/redis/redis-console/src/test/java/com/ctrip/xpipe/redis/console/dao/RedisDaoTest.java
+++ b/redis/redis-console/src/test/java/com/ctrip/xpipe/redis/console/dao/RedisDaoTest.java
@@ -10,6 +10,9 @@ import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.unidal.dal.jdbc.DalException;
 
+import java.util.Collections;
+import java.util.Calendar;
+import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -65,6 +68,64 @@ public class RedisDaoTest extends AbstractConsoleIntegrationTest {
             Assert.assertEquals(redisTbl.isKeeperActive(), byPK.isKeeperActive());
         }
 
+    }
+
+    @Test
+    public void testUpdateBatchPreservesCreateTime() throws Exception {
+        RedisTbl redis = redises.get(0);
+        executeSqlScript(String.format(
+                "UPDATE REDIS_TBL SET create_time = '2023-11-14 22:13:20' WHERE id = %d", redis.getId()));
+        Date expectedCreateTime = redisDao.findByPK(redis.getId()).getCreateTime();
+
+        RedisTbl updateProto = new RedisTbl()
+                .setId(redis.getId())
+                .setRedisIp(redis.getRedisIp())
+                .setRedisPort(redis.getRedisPort())
+                .setRunId(redis.getRunId())
+                .setKeeperActive(redis.isKeeperActive())
+                .setMaster(!redis.isMaster())
+                .setKeepercontainerId(redis.getKeepercontainerId())
+                .setRedisRole(redis.getRedisRole())
+                .setDcClusterShardId(redis.getDcClusterShardId())
+                .setAzId(redis.getAzId());
+
+        redisDao.updateBatch(Collections.singletonList(updateProto));
+
+        RedisTbl fromDb = redisDao.findByPK(redis.getId());
+        Assert.assertEquals(expectedCreateTime, fromDb.getCreateTime());
+        Assert.assertEquals(updateProto.isMaster(), fromDb.isMaster());
+    }
+
+    @Test
+    public void testCreateRedisesBatchPersistsExplicitCreateTime() throws DalException {
+        Date expectedCreateTime = dateTime(2024, 6, 18, 14, 30, 0);
+        RedisTbl redis = createRedis(XPipeConsoleConstant.ROLE_REDIS)
+                .setCreateTime(expectedCreateTime);
+
+        redisDao.createRedisesBatch(Collections.singletonList(redis));
+
+        Assert.assertEquals(expectedCreateTime, redisDao.findByPK(redis.getId()).getCreateTime());
+    }
+
+    @Test
+    public void testCreateTimeBeyond2038RoundTrip() throws Exception {
+        Date expectedCreateTime = dateTime(2040, 1, 15, 10, 20, 30);
+
+        RedisTbl redis = createRedis(XPipeConsoleConstant.ROLE_REDIS)
+                .setCreateTime(expectedCreateTime);
+        redisDao.createRedisesBatch(Collections.singletonList(redis));
+        Assert.assertEquals(expectedCreateTime, redisDao.findByPK(redis.getId()).getCreateTime());
+
+        executeSqlScript(String.format(
+                "UPDATE REDIS_TBL SET create_time = '2040-01-15 10:20:30' WHERE id = %d", redis.getId()));
+        Assert.assertEquals(expectedCreateTime, redisDao.findByPK(redis.getId()).getCreateTime());
+    }
+
+    private static Date dateTime(int year, int month, int day, int hour, int minute, int second) {
+        Calendar calendar = Calendar.getInstance();
+        calendar.set(Calendar.MILLISECOND, 0);
+        calendar.set(year, month - 1, day, hour, minute, second);
+        return calendar.getTime();
     }
 
     private List<RedisTbl> createRedises(int count) {

--- a/redis/redis-console/src/test/java/com/ctrip/xpipe/redis/console/ds/XPipeDataObjectAccessorTest.java
+++ b/redis/redis-console/src/test/java/com/ctrip/xpipe/redis/console/ds/XPipeDataObjectAccessorTest.java
@@ -1,0 +1,124 @@
+package com.ctrip.xpipe.redis.console.ds;
+
+import com.ctrip.xpipe.redis.console.model.RedisTbl;
+import org.codehaus.plexus.logging.AbstractLogger;
+import org.codehaus.plexus.logging.Logger;
+import org.junit.Assert;
+import org.junit.Test;
+import org.unidal.dal.jdbc.DalRuntimeException;
+import org.unidal.dal.jdbc.DataField;
+import org.unidal.dal.jdbc.entity.DataObjectAccessor;
+import org.unidal.dal.jdbc.entity.DefaultDataObjectAccessor;
+import org.unidal.dal.jdbc.entity.DefaultDataObjectNaming;
+
+import java.lang.reflect.Field;
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+
+public class XPipeDataObjectAccessorTest {
+
+    private static final String CREATE_TIME_FIELD = "create-time";
+
+    @Test
+    public void setCreateTimeFromLocalDateTime2040() throws Exception {
+        LocalDateTime fromDb = LocalDateTime.of(2040, 1, 15, 10, 20, 30);
+        RedisTbl row = setCreateTime(newAccessor(), fromDb);
+        Assert.assertEquals(Timestamp.valueOf(fromDb), row.getCreateTime());
+    }
+
+    @Test
+    public void setCreateTimeFromLocalDateTimeNow() throws Exception {
+        LocalDateTime fromDb = LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS);
+        RedisTbl row = setCreateTime(newAccessor(), fromDb);
+        Assert.assertEquals(Timestamp.valueOf(fromDb), row.getCreateTime());
+    }
+
+    @Test
+    public void setCreateTimeFromNull() throws Exception {
+        RedisTbl row = setCreateTime(newAccessor(), null);
+        Assert.assertNull(row.getCreateTime());
+    }
+
+    @Test
+    public void setCreateTimeFromDate() throws Exception {
+        Date expected = new Date();
+        RedisTbl row = setCreateTime(newAccessor(), expected);
+        Assert.assertSame(expected, row.getCreateTime());
+    }
+
+    @Test
+    public void setCreateTimeFromTimestamp() throws Exception {
+        Timestamp expected = Timestamp.valueOf(LocalDateTime.of(2023, 11, 14, 22, 13, 20));
+        RedisTbl row = setCreateTime(newAccessor(), expected);
+        Assert.assertSame(expected, row.getCreateTime());
+    }
+
+    @Test
+    public void setCreateTimeFromLocalDate() throws Exception {
+        LocalDate fromDb = LocalDate.of(2024, 6, 18);
+        RedisTbl row = setCreateTime(newAccessor(), fromDb);
+        Assert.assertEquals(java.sql.Date.valueOf(fromDb), row.getCreateTime());
+    }
+
+    @Test(expected = DalRuntimeException.class)
+    public void defaultAccessorRejectsLocalDateTime() throws Exception {
+        DefaultDataObjectAccessor accessor = new DefaultDataObjectAccessor();
+        accessor.enableLogging(new NullLogger(Logger.LEVEL_ERROR, "defaultAccessor"));
+        LocalDateTime fromDb = LocalDateTime.of(2040, 1, 15, 10, 20, 30);
+        setCreateTime(accessor, fromDb);
+    }
+
+    private static RedisTbl setCreateTime(DataObjectAccessor accessor, Object value) throws Exception {
+        initNaming(accessor);
+        RedisTbl row = new RedisTbl();
+        DataField field = new DataField(CREATE_TIME_FIELD);
+        field.setEntityClass(RedisTbl.class);
+        accessor.setFieldValue(row, field, value);
+        return row;
+    }
+
+    private static XPipeDataObjectAccessor newAccessor() {
+        return new XPipeDataObjectAccessor();
+    }
+
+    private static void initNaming(DataObjectAccessor accessor) throws Exception {
+        Field naming = DefaultDataObjectAccessor.class.getDeclaredField("m_naming");
+        naming.setAccessible(true);
+        naming.set(accessor, new DefaultDataObjectNaming());
+    }
+
+    private static final class NullLogger extends AbstractLogger {
+
+        private NullLogger(int threshold, String name) {
+            super(threshold, name);
+        }
+
+        @Override
+        public void debug(String message, Throwable throwable) {
+        }
+
+        @Override
+        public void info(String message, Throwable throwable) {
+        }
+
+        @Override
+        public void warn(String message, Throwable throwable) {
+        }
+
+        @Override
+        public void error(String message, Throwable throwable) {
+        }
+
+        @Override
+        public void fatalError(String message, Throwable throwable) {
+        }
+
+        @Override
+        public Logger getChildLogger(String name) {
+            return this;
+        }
+    }
+}

--- a/redis/redis-console/src/test/java/com/ctrip/xpipe/redis/console/service/impl/RedisServiceImplTest.java
+++ b/redis/redis-console/src/test/java/com/ctrip/xpipe/redis/console/service/impl/RedisServiceImplTest.java
@@ -207,6 +207,39 @@ public class RedisServiceImplTest extends AbstractServiceImplTest {
 
     }
 
+    @Test
+    public void testUpdateRedisesPreservesCreateTime() throws IOException, ResourceNotFoundException {
+        Date expectedCreateTime = new Date(1_700_000_000_000L);
+        List<RedisTbl> instances = redisService.findAllByDcClusterShard(dcName, clusterName, shardName);
+        for (RedisTbl redisTbl : instances) {
+            if (redisTbl.getRedisRole().equals(XPipeConsoleConstant.ROLE_REDIS)) {
+                redisTbl.setCreateTime(expectedCreateTime);
+                redisService.updateByPK(redisTbl);
+            }
+        }
+
+        boolean firstSlave = true;
+        for (RedisTbl redisTbl : instances) {
+            if (redisTbl.getRedisRole().equals(XPipeConsoleConstant.ROLE_REDIS)) {
+                if (redisTbl.isMaster()) {
+                    redisTbl.setMaster(false);
+                } else if (firstSlave) {
+                    redisTbl.setMaster(true);
+                    firstSlave = false;
+                }
+            }
+        }
+
+        redisService.updateRedises(dcName, clusterName, shardName, new ShardModel(instances));
+
+        instances = redisService.findAllByDcClusterShard(dcName, clusterName, shardName);
+        for (RedisTbl redisTbl : instances) {
+            if (redisTbl.getRedisRole().equals(XPipeConsoleConstant.ROLE_REDIS)) {
+                Assert.assertEquals(expectedCreateTime, redisTbl.getCreateTime());
+            }
+        }
+    }
+
     private void checkAllInstances(List<RedisTbl> allByDcClusterShard) {
 
         Assert.assertEquals(4, allByDcClusterShard.size());

--- a/redis/redis-console/src/test/java/com/ctrip/xpipe/redis/console/service/meta/impl/RedisMetaServiceImplTest.java
+++ b/redis/redis-console/src/test/java/com/ctrip/xpipe/redis/console/service/meta/impl/RedisMetaServiceImplTest.java
@@ -1,5 +1,7 @@
 package com.ctrip.xpipe.redis.console.service.meta.impl;
 
+import com.ctrip.xpipe.AbstractTest;
+import com.ctrip.xpipe.redis.console.AbstractConsoleIntegrationTest;
 import com.ctrip.xpipe.redis.console.cache.AzCache;
 import com.ctrip.xpipe.redis.console.model.AzTbl;
 import com.ctrip.xpipe.redis.console.model.RedisTbl;
@@ -14,10 +16,12 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.Date;
+
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
-public class RedisMetaServiceImplTest {
+public class RedisMetaServiceImplTest extends AbstractTest {
 
     @InjectMocks
     private RedisMetaServiceImpl redisMetaService;
@@ -90,4 +94,36 @@ public class RedisMetaServiceImplTest {
 
         Assert.assertNull(result.getAz());
     }
+
+    @Test
+    public void testGetRedisMetaCopiesCreateTime() {
+        RedisMetaServiceImpl redisMetaService = new RedisMetaServiceImpl();
+        Date createTime = new Date();
+        RedisTbl redisTbl = new RedisTbl();
+        redisTbl.setRunId("run-id");
+        redisTbl.setRedisIp("127.0.0.1");
+        redisTbl.setRedisPort(6379);
+        redisTbl.setMaster(true);
+        redisTbl.setCreateTime(createTime);
+
+        ShardMeta shardMeta = new ShardMeta();
+        RedisMeta redisMeta = redisMetaService.getRedisMeta(shardMeta, redisTbl);
+
+        Assert.assertEquals(createTime.getTime(), redisMeta.getCreateTime().longValue());
+    }
+
+    @Test
+    public void testGetRedisMetaWithoutCreateTime() {
+        RedisMetaServiceImpl redisMetaService = new RedisMetaServiceImpl();
+        RedisTbl redisTbl = new RedisTbl();
+        redisTbl.setRunId("run-id");
+        redisTbl.setRedisIp("127.0.0.1");
+        redisTbl.setRedisPort(6379);
+        redisTbl.setMaster(true);
+
+        RedisMeta redisMeta = redisMetaService.getRedisMeta(new ShardMeta(), redisTbl);
+
+        Assert.assertNull(redisMeta.getCreateTime());
+    }
+
 }

--- a/redis/redis-console/src/test/java/com/ctrip/xpipe/redis/console/service/vo/DcMetaBuilderTest.java
+++ b/redis/redis-console/src/test/java/com/ctrip/xpipe/redis/console/service/vo/DcMetaBuilderTest.java
@@ -13,6 +13,7 @@ import com.ctrip.xpipe.redis.console.service.meta.RedisMetaService;
 import com.ctrip.xpipe.redis.console.service.migration.MigrationService;
 import com.ctrip.xpipe.redis.core.entity.ClusterMeta;
 import com.ctrip.xpipe.redis.core.entity.DcMeta;
+import com.ctrip.xpipe.redis.core.entity.RedisMeta;
 import com.ctrip.xpipe.redis.core.entity.ShardMeta;
 import com.ctrip.xpipe.redis.core.entity.SourceMeta;
 import com.google.common.collect.Lists;
@@ -58,6 +59,9 @@ public class DcMetaBuilderTest extends AbstractConsoleIntegrationTest {
 
     @Autowired
     private ClusterService clusterService;
+
+    @Autowired
+    private RedisService redisService;
 
     @Autowired
     private ConsoleConfig consoleConfig;
@@ -151,6 +155,36 @@ public class DcMetaBuilderTest extends AbstractConsoleIntegrationTest {
         logger.info("{}", shardMeta);
     }
 
+
+    @Test
+    public void testBuiltRedisMetaContainsCreateTime() throws Exception {
+        Date expectedCreateTime = new Date(1_700_000_000_000L);
+        RedisTbl redisTbl = redisService.find(3L);
+        Assert.assertNotNull(redisTbl);
+        redisTbl.setCreateTime(expectedCreateTime);
+        redisService.updateByPK(redisTbl);
+
+        DcMeta builtDcMeta = new DcMeta();
+        dcMetaMap.clear();
+        dcMetaMap.put("JQ", builtDcMeta);
+
+        new DcMetaBuilder(dcMetaMap, dcService.findAllDcs(), Collections.singleton(ClusterType.ONE_WAY.toString()),
+                executors, redisMetaService, dcClusterService, clusterMetaService, dcClusterShardService, dcService,
+                azGroupClusterRepository, azGroupCache, new DefaultRetryCommandFactory(), consoleConfig)
+                .execute().get();
+
+        ClusterMeta clusterMeta = builtDcMeta.findCluster("cluster1");
+        Assert.assertNotNull(clusterMeta);
+        ShardMeta shardMeta = clusterMeta.findShard("shard1");
+        Assert.assertNotNull(shardMeta);
+
+        RedisMeta redisMeta = shardMeta.getRedises().stream()
+                .filter(redis -> redis.getPort() == 6379)
+                .findFirst()
+                .orElse(null);
+        Assert.assertNotNull(redisMeta);
+        Assert.assertEquals(expectedCreateTime.getTime(), redisMeta.getCreateTime().longValue());
+    }
 
     @Test
     public void testClusterBondToOnlyOneIDC() throws Exception {

--- a/redis/redis-core/src/main/resources/META-INF/dal/model/keeper-codegen.xml
+++ b/redis/redis-core/src/main/resources/META-INF/dal/model/keeper-codegen.xml
@@ -122,6 +122,7 @@
     <attribute name="gid" value-type="int" />
     <attribute name="sid" value-type="String" />
     <attribute name="gtid" value-type="String" />
+    <attribute name="createTime" value-type="long" />
   </entity>
   <entity name="route">
     <attribute name="id" value-type="long" />

--- a/redis/redis-core/src/main/resources/META-INF/dal/model/keeper-model.xml
+++ b/redis/redis-core/src/main/resources/META-INF/dal/model/keeper-model.xml
@@ -94,6 +94,7 @@
 		<attribute name="offset" value-type="Long" />
 		<attribute name="gid" value-type="Long" />
 		<attribute name="az" value-type="String" />
+		<attribute name="createTime" value-type="Long" />
 		<snippet>
 			public boolean isMaster(){
 			return m_master == null || m_master.trim().length() == 0;


### PR DESCRIPTION
…edis instances

Propagate REDIS_TBL.create_time through Meta to Checker, replace obsolete delayType tag, and add tests for metric tagging and shard update safety.