### PR TITLE
fix RedisNettyClient gate control

### DIFF
--- a/core/src/main/java/com/ctrip/xpipe/netty/commands/RedisNettyClient.java
+++ b/core/src/main/java/com/ctrip/xpipe/netty/commands/RedisNettyClient.java
@@ -4,6 +4,8 @@ public interface RedisNettyClient {
 
     boolean getDoAfterConnectedOver();
 
+    boolean getDoAfterConnectedSuccess();
+
     int getAfterConnectCommandTimeoutMill();
 
 }

--- a/redis/redis-core/src/main/java/com/ctrip/xpipe/redis/core/client/NettyRedisPoolClientFactory.java
+++ b/redis/redis-core/src/main/java/com/ctrip/xpipe/redis/core/client/NettyRedisPoolClientFactory.java
@@ -4,6 +4,7 @@ import com.ctrip.xpipe.api.endpoint.Endpoint;
 import com.ctrip.xpipe.netty.commands.NettyClient;
 import com.ctrip.xpipe.netty.commands.NettyClientHandler;
 import com.ctrip.xpipe.netty.commands.NettyKeyedPoolClientFactory;
+import com.ctrip.xpipe.netty.commands.RedisNettyClient;
 import io.netty.channel.ChannelFuture;
 import org.apache.commons.pool2.PooledObject;
 import org.apache.commons.pool2.impl.DefaultPooledObject;
@@ -26,6 +27,19 @@ public class NettyRedisPoolClientFactory extends NettyKeyedPoolClientFactory {
         NettyClient nettyClient = new RedisAsyncNettyClient(f, key, clientName, asyncConnectionCondition);
         f.channel().attr(NettyClientHandler.KEY_CLIENT).set(nettyClient);
         return new DefaultPooledObject<NettyClient>(nettyClient);
+    }
+
+    @Override
+    public boolean validateObject(Endpoint key, PooledObject<NettyClient> p) {
+        if (!super.validateObject(key, p)) {
+            return false;
+        }
+        NettyClient client = p.getObject();
+        if (client instanceof RedisNettyClient) {
+            RedisNettyClient redisClient = (RedisNettyClient) client;
+            return !redisClient.getDoAfterConnectedOver() || redisClient.getDoAfterConnectedSuccess();
+        }
+        return true;
     }
 
 }

--- a/redis/redis-core/src/main/java/com/ctrip/xpipe/redis/core/client/RedisAsyncNettyClient.java
+++ b/redis/redis-core/src/main/java/com/ctrip/xpipe/redis/core/client/RedisAsyncNettyClient.java
@@ -1,8 +1,6 @@
 package com.ctrip.xpipe.redis.core.client;
 
 import com.ctrip.xpipe.api.endpoint.Endpoint;
-import com.ctrip.xpipe.api.monitor.Task;
-import com.ctrip.xpipe.api.monitor.TransactionMonitor;
 import com.ctrip.xpipe.exception.XpipeException;
 import com.ctrip.xpipe.netty.commands.AsyncNettyClient;
 import com.ctrip.xpipe.netty.commands.ByteBufReceiver;
@@ -12,7 +10,6 @@ import com.ctrip.xpipe.redis.core.protocal.RedisClientProtocol;
 import com.ctrip.xpipe.redis.core.protocal.protocal.RequestStringParser;
 import com.ctrip.xpipe.redis.core.protocal.protocal.SimpleStringParser;
 import com.ctrip.xpipe.utils.ChannelUtil;
-import com.ctrip.xpipe.utils.VisibleForTesting;
 import com.dianping.cat.Cat;
 import com.dianping.cat.message.Transaction;
 import io.netty.buffer.ByteBuf;
@@ -23,9 +20,8 @@ import io.netty.util.concurrent.GenericFutureListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class RedisAsyncNettyClient extends AsyncNettyClient implements RedisNettyClient {
 
@@ -41,9 +37,11 @@ public class RedisAsyncNettyClient extends AsyncNettyClient implements RedisNett
 
     private static final int DEFAULT_REDIS_COMMAND_TIME_OUT_MILLI = 660;
 
-    private boolean doAfterConnectedSuccess = false;
+    private final AtomicBoolean doAfterConnectedSuccess = new AtomicBoolean(false);
 
-    protected final AtomicReference<Boolean> doAfterConnectedOver = new AtomicReference<>(false);
+    private final AtomicBoolean doAfterConnectedOver = new AtomicBoolean(false);
+
+    private final CompletableFuture<Boolean> afterConnectedFuture = new CompletableFuture<>();
 
     public RedisAsyncNettyClient(ChannelFuture future, Endpoint endpoint, String clientName, AsyncConnectionCondition asyncConnectionCondition) {
         super(future, endpoint);
@@ -54,7 +52,8 @@ public class RedisAsyncNettyClient extends AsyncNettyClient implements RedisNett
             public void operationComplete(Future<? super Void> future) throws Exception {
                 if (future.isSuccess()) {
                     doAfterConnected();
-                    doAfterConnectedOver.set(true);
+                } else {
+                    finishAfterConnected(false);
                 }
             }
         });
@@ -62,6 +61,7 @@ public class RedisAsyncNettyClient extends AsyncNettyClient implements RedisNett
 
     protected void doAfterConnected() {
         if (asyncConnectionCondition != null && !asyncConnectionCondition.shouldDo()) {
+            finishAfterConnected(true);
             return;
         }
         RequestStringParser requestString = new RequestStringParser(CLIENT_SET_NAME, clientName);
@@ -84,16 +84,16 @@ public class RedisAsyncNettyClient extends AsyncNettyClient implements RedisNett
                         }
                         if (EXPECT_RESP.equalsIgnoreCase(result)){
                             transaction.setStatus(Transaction.SUCCESS);
-                            doAfterConnectedSuccess = true;
                             logger.info("[redisAsync][clientSetName][success][{}] {}", desc, result);
+                            finishAfterConnected(true);
                         } else {
-                            doAfterConnectedSuccess = false;
                             transaction.setStatus(new XpipeException(String.format("[redisAsync][clientSetName][wont-result][%s] result:%s", desc, result)));
                             logger.warn("[redisAsync][clientSetName][err-result][{}] {}", desc, result);
+                            finishAfterConnected(false);
                         }
                         transaction.complete();
                     }catch(Throwable th){
-                        doAfterConnectedSuccess = false;
+                        finishAfterConnected(false);
                         transaction.setStatus(th);
                         transaction.complete();
                         logger.error("[logTransaction]" + "netty.client.setName" + "," + clientName, th);
@@ -107,6 +107,7 @@ public class RedisAsyncNettyClient extends AsyncNettyClient implements RedisNett
                     logger.warn("[redisAsync][clientSetName][wont-send][{}] {}", desc, nettyClient.channel());
                     transaction.setStatus(new XpipeException(String.format("[redisAsync][clientSetName][wont-send][%s]client closed %s", desc, nettyClient.channel())));
                     transaction.complete();
+                    finishAfterConnected(false);
                 }
 
                 @Override
@@ -114,14 +115,66 @@ public class RedisAsyncNettyClient extends AsyncNettyClient implements RedisNett
                     logger.warn("[redisAsync][clientSetName][wont-send][{}] {}", desc, nettyClient.channel(), th);
                     transaction.setStatus(th);
                     transaction.complete();
+                    finishAfterConnected(false);
                 }
             });
         } catch (Exception e) {
             transaction.setStatus(e);
             transaction.complete();
             logger.error("[redisAsync][clientSetName] err", e);
+            finishAfterConnected(false);
         }
 
+    }
+
+    private void finishAfterConnected(boolean success) {
+        if (doAfterConnectedOver.compareAndSet(false, true)) {
+            doAfterConnectedSuccess.set(success);
+            afterConnectedFuture.complete(success);
+            if (!success && channel != null) {
+                channel.close();
+            }
+        }
+    }
+
+    @Override
+    public void sendRequest(ByteBuf byteBuf) {
+        if (doAfterConnectedOver.get()) {
+            if (doAfterConnectedSuccess.get()) {
+                super.sendRequest(byteBuf);
+            } else {
+                logger.warn("[async][wont-send][afterConnected-fail][{}]", desc);
+            }
+            return;
+        }
+        afterConnectedFuture.whenComplete((success, throwable) -> {
+            if (Boolean.TRUE.equals(success)) {
+                RedisAsyncNettyClient.super.sendRequest(byteBuf);
+            } else {
+                logger.warn("[async][wont-send][afterConnected-fail][{}]", desc);
+            }
+        });
+    }
+
+    @Override
+    public void sendRequest(ByteBuf byteBuf, ByteBufReceiver byteBufReceiver) {
+        if (doAfterConnectedOver.get()) {
+            if (doAfterConnectedSuccess.get()) {
+                super.sendRequest(byteBuf, byteBufReceiver);
+            } else {
+                logger.warn("[async][wont-send][afterConnected-fail][{}] {}", desc, byteBufReceiver.getClass().getSimpleName());
+                byteBufReceiver.clientClosed(this);
+            }
+            return;
+        }
+        afterConnectedFuture.whenComplete((success, throwable) -> {
+            if (Boolean.TRUE.equals(success)) {
+                RedisAsyncNettyClient.super.sendRequest(byteBuf, byteBufReceiver);
+            } else {
+                logger.warn("[async][wont-send][afterConnected-fail][{}] {}", desc, byteBufReceiver.getClass().getSimpleName());
+                byteBufReceiver.clientClosed(RedisAsyncNettyClient.this);
+            }
+        });
     }
 
     @Override
@@ -130,13 +183,13 @@ public class RedisAsyncNettyClient extends AsyncNettyClient implements RedisNett
     }
 
     @Override
-    public int getAfterConnectCommandTimeoutMill() {
-        return DEFAULT_REDIS_COMMAND_TIME_OUT_MILLI;
+    public boolean getDoAfterConnectedSuccess() {
+        return doAfterConnectedSuccess.get();
     }
 
-    @VisibleForTesting
-    public boolean getDoAfterConnectedSuccess() {
-        return doAfterConnectedSuccess;
+    @Override
+    public int getAfterConnectCommandTimeoutMill() {
+        return DEFAULT_REDIS_COMMAND_TIME_OUT_MILLI;
     }
 
 }

--- a/redis/redis-core/src/test/java/com/ctrip/xpipe/redis/core/client/RedisAsyncNettyClientTest.java
+++ b/redis/redis-core/src/test/java/com/ctrip/xpipe/redis/core/client/RedisAsyncNettyClientTest.java
@@ -21,8 +21,15 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.Socket;
-import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class RedisAsyncNettyClientTest extends AsyncNettyClientTest {
 
@@ -34,29 +41,25 @@ public class RedisAsyncNettyClientTest extends AsyncNettyClientTest {
     }
 
     @Test
-    public void testStickyBag() throws Exception {
-        server = startEchoServer(randomPort(), "+OK\r\n+OK1\r\n+OK2");
+    public void testBusinessWaitsSetName() throws Exception {
+        server = startRedisLikeServer(randomPort(), "+OK1\r\n");
         RedisAsyncNettyClient client = new RedisAsyncNettyClient(b.connect("localhost", server.getPort()),
                 new DefaultEndPoint("localhost", server.getPort()), "xpipe", () -> true);
         client.channel().attr(NettyClientHandler.KEY_CLIENT).set(client);
 
         StringBuffer sb = new StringBuffer();
-
-        StringBuilder expected = new StringBuilder();
+        AtomicBoolean setNameDoneBeforeBusinessReceive = new AtomicBoolean(false);
 
         String message = "+1" + "\r\n";
-        final int[] minReadAbleBytes = {Integer.MAX_VALUE};
         client.sendRequest(Unpooled.copiedBuffer(message.getBytes()), new ByteBufReceiver() {
 
             private RedisClientProtocol<String> parser = new SimpleStringParser();
             @Override
             public RECEIVER_RESULT receive(Channel channel, ByteBuf byteBuf) {
+                setNameDoneBeforeBusinessReceive.set(client.getDoAfterConnectedSuccess());
                 RedisClientProtocol<String> clientProtocol = parser.read(byteBuf);
                 if(clientProtocol != null) {
                     sb.append(clientProtocol.getPayload());
-                    if (byteBuf.readableBytes() < minReadAbleBytes[0]) {
-                        minReadAbleBytes[0] = byteBuf.readableBytes();
-                    }
                     return RECEIVER_RESULT.SUCCESS;
                 }
                 return RECEIVER_RESULT.CONTINUE;
@@ -72,26 +75,22 @@ public class RedisAsyncNettyClientTest extends AsyncNettyClientTest {
 
             }
         });
-        expected.append("OK1");
-        waitConditionUntilTimeOut(()->client.channel().isActive(), 1000);
-        sleep(1000);
-        String str = sb.toString();
-        Assert.assertTrue(minReadAbleBytes[0] > 0);
-        Assert.assertTrue(client.getDoAfterConnectedSuccess());
-        Assert.assertEquals(str, expected.toString());
+        waitConditionUntilTimeOut(client::getDoAfterConnectedSuccess, 2000);
+        waitConditionUntilTimeOut(() -> sb.length() > 0, 2000);
+        Assert.assertTrue(client.getDoAfterConnectedOver());
+        Assert.assertTrue(setNameDoneBeforeBusinessReceive.get());
+        Assert.assertEquals("OK1", sb.toString());
     }
 
     @Test
-    public void testUnpacking() throws Exception {
+    public void testUnpackingSetNameThenBusiness() throws Exception {
         server = startUnpackingServer(randomPort(), "+O");
         RedisAsyncNettyClient client = new RedisAsyncNettyClient(b.connect("localhost", server.getPort()),
                 new DefaultEndPoint("localhost", server.getPort()), "xpipe", () -> true);
         client.channel().attr(NettyClientHandler.KEY_CLIENT).set(client);
 
         StringBuffer sb = new StringBuffer();
-
-        StringBuilder expected = new StringBuilder();
-        String message = "K\r\nOK1\r\n";
+        String message = "ping\r\n";
         client.sendRequest(Unpooled.copiedBuffer(message.getBytes()), new ByteBufReceiver() {
 
             private RedisClientProtocol<String> parser = new SimpleStringParser();
@@ -115,19 +114,225 @@ public class RedisAsyncNettyClientTest extends AsyncNettyClientTest {
 
             }
         });
-        expected.append("OK1");
-        waitConditionUntilTimeOut(()->client.channel().isActive(), 1000);
-        sleep(1000);
-        String str = sb.toString();
+        waitConditionUntilTimeOut(client::getDoAfterConnectedSuccess, 2000);
+        waitConditionUntilTimeOut(() -> sb.length() > 0, 2000);
         Assert.assertTrue(client.getDoAfterConnectedSuccess());
-        Assert.assertEquals(str, expected.toString());
+        Assert.assertEquals("PONG", sb.toString());
+    }
+
+    @Test
+    public void testCrossThreadBusinessWaitsSetNameOnWire() throws Exception {
+        List<String> receivedOrder = Collections.synchronizedList(new ArrayList<>());
+        server = startOrderTrackingServer(randomPort(), 300, receivedOrder, "+PONG\r\n");
+        RedisAsyncNettyClient client = createClient(server.getPort());
+
+        waitConditionUntilTimeOut(() -> client.channel().isActive(), 2000);
+
+        CountDownLatch businessDone = new CountDownLatch(1);
+        AtomicReference<String> businessSendThread = new AtomicReference<>();
+        AtomicReference<String> businessReceiveThread = new AtomicReference<>();
+        AtomicBoolean businessReceived = new AtomicBoolean(false);
+
+        Thread businessThread = new Thread(() -> {
+            businessSendThread.set(Thread.currentThread().getName());
+            client.sendRequest(Unpooled.copiedBuffer("ping\r\n".getBytes()), new ByteBufReceiver() {
+                private final RedisClientProtocol<String> parser = new SimpleStringParser();
+
+                @Override
+                public RECEIVER_RESULT receive(Channel channel, ByteBuf byteBuf) {
+                    businessReceiveThread.set(Thread.currentThread().getName());
+                    RedisClientProtocol<String> clientProtocol = parser.read(byteBuf);
+                    if (clientProtocol != null) {
+                        businessReceived.set(true);
+                        businessDone.countDown();
+                        return RECEIVER_RESULT.SUCCESS;
+                    }
+                    return RECEIVER_RESULT.CONTINUE;
+                }
+
+                @Override
+                public void clientClosed(NettyClient nettyClient) {
+                    businessDone.countDown();
+                }
+
+                @Override
+                public void clientClosed(NettyClient nettyClient, Throwable th) {
+                    businessDone.countDown();
+                }
+            });
+        }, "business-thread");
+        businessThread.start();
+
+        Assert.assertTrue("business should finish after setname", businessDone.await(5, TimeUnit.SECONDS));
+        waitConditionUntilTimeOut(client::getDoAfterConnectedSuccess, 2000);
+
+        Assert.assertTrue(receivedOrder.size() >= 2);
+        Assert.assertTrue(receivedOrder.get(0).toUpperCase().contains("CLIENT"));
+        Assert.assertFalse(receivedOrder.get(1).toUpperCase().contains("CLIENT"));
+        Assert.assertTrue(businessReceived.get());
+        Assert.assertEquals("business-thread", businessSendThread.get());
+        Assert.assertEquals(captureEventLoopThreadName(client), businessReceiveThread.get());
+    }
+
+    @Test
+    public void testBusinessSendRequestRegistersWhileSetNameInFlight() throws Exception {
+        CountDownLatch setNameReceived = new CountDownLatch(1);
+        server = startOrderTrackingServer(randomPort(), 500, Collections.synchronizedList(new ArrayList<>()),
+                "+PONG\r\n", setNameReceived);
+        RedisAsyncNettyClient client = createClient(server.getPort());
+
+        waitConditionUntilTimeOut(() -> client.channel().isActive(), 2000);
+        Assert.assertTrue(setNameReceived.await(2, TimeUnit.SECONDS));
+
+        AtomicBoolean queuedWhileSetNameInFlight = new AtomicBoolean(false);
+        CountDownLatch businessDone = new CountDownLatch(1);
+
+        Thread businessThread = new Thread(() -> {
+            queuedWhileSetNameInFlight.set(!client.getDoAfterConnectedOver());
+            client.sendRequest(Unpooled.copiedBuffer("ping\r\n".getBytes()), noopReceiver(businessDone));
+        }, "business-thread");
+        businessThread.start();
+
+        Assert.assertTrue(businessDone.await(5, TimeUnit.SECONDS));
+        waitConditionUntilTimeOut(client::getDoAfterConnectedSuccess, 2000);
+        Assert.assertTrue("business sendRequest should be queued before setname completes", queuedWhileSetNameInFlight.get());
+    }
+
+    @Test
+    public void testMultipleBusinessThreadsAfterSetNameOnWire() throws Exception {
+        List<String> receivedOrder = Collections.synchronizedList(new ArrayList<>());
+        server = startOrderTrackingServer(randomPort(), 200, receivedOrder, "+PONG\r\n");
+        RedisAsyncNettyClient client = createClient(server.getPort());
+
+        waitConditionUntilTimeOut(() -> client.channel().isActive(), 2000);
+
+        int businessThreadCount = 8;
+        CountDownLatch allDone = new CountDownLatch(businessThreadCount);
+        for (int i = 0; i < businessThreadCount; i++) {
+            final int idx = i;
+            new Thread(() -> client.sendRequest(Unpooled.copiedBuffer(("ping" + idx + "\r\n").getBytes()), noopReceiver(allDone)),
+                    "business-thread-" + idx).start();
+        }
+
+        Assert.assertTrue(allDone.await(10, TimeUnit.SECONDS));
+        waitConditionUntilTimeOut(client::getDoAfterConnectedSuccess, 2000);
+
+        Assert.assertTrue(receivedOrder.get(0).toUpperCase().contains("CLIENT"));
+        for (int i = 1; i < receivedOrder.size(); i++) {
+            Assert.assertFalse(receivedOrder.get(i).toUpperCase().contains("CLIENT"));
+        }
+        Assert.assertEquals(1 + businessThreadCount, receivedOrder.size());
+    }
+
+    @Test
+    public void testSkipSetNameFromAnotherThread() throws Exception {
+        List<String> receivedOrder = Collections.synchronizedList(new ArrayList<>());
+        server = startOrderTrackingServer(randomPort(), 0, receivedOrder, "+PONG\r\n");
+        RedisAsyncNettyClient client = new RedisAsyncNettyClient(b.connect("localhost", server.getPort()),
+                new DefaultEndPoint("localhost", server.getPort()), "xpipe", () -> false);
+        client.channel().attr(NettyClientHandler.KEY_CLIENT).set(client);
+
+        CountDownLatch businessDone = new CountDownLatch(1);
+        new Thread(() -> client.sendRequest(Unpooled.copiedBuffer("ping\r\n".getBytes()), noopReceiver(businessDone)),
+                "business-thread").start();
+
+        Assert.assertTrue(businessDone.await(5, TimeUnit.SECONDS));
+        waitConditionUntilTimeOut(client::getDoAfterConnectedSuccess, 2000);
+        Assert.assertEquals(1, receivedOrder.size());
+        Assert.assertFalse(receivedOrder.get(0).toUpperCase().contains("CLIENT"));
+    }
+
+    private RedisAsyncNettyClient createClient(int port) {
+        RedisAsyncNettyClient client = new RedisAsyncNettyClient(b.connect("localhost", port),
+                new DefaultEndPoint("localhost", port), "xpipe", () -> true);
+        client.channel().attr(NettyClientHandler.KEY_CLIENT).set(client);
+        return client;
+    }
+
+    private String captureEventLoopThreadName(RedisAsyncNettyClient client) throws Exception {
+        AtomicReference<String> eventLoopThread = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        client.channel().eventLoop().execute(() -> {
+            eventLoopThread.set(Thread.currentThread().getName());
+            latch.countDown();
+        });
+        Assert.assertTrue(latch.await(2, TimeUnit.SECONDS));
+        return eventLoopThread.get();
+    }
+
+    private ByteBufReceiver noopReceiver(CountDownLatch done) {
+        return new ByteBufReceiver() {
+            private final RedisClientProtocol<String> parser = new SimpleStringParser();
+
+            @Override
+            public RECEIVER_RESULT receive(Channel channel, ByteBuf byteBuf) {
+                if (parser.read(byteBuf) != null) {
+                    done.countDown();
+                    return RECEIVER_RESULT.SUCCESS;
+                }
+                return RECEIVER_RESULT.CONTINUE;
+            }
+
+            @Override
+            public void clientClosed(NettyClient nettyClient) {
+                done.countDown();
+            }
+
+            @Override
+            public void clientClosed(NettyClient nettyClient, Throwable th) {
+                done.countDown();
+            }
+        };
+    }
+
+    protected Server startOrderTrackingServer(int port, int setNameDelayMs, List<String> receivedOrder,
+                                              String businessResponse) throws Exception {
+        return startOrderTrackingServer(port, setNameDelayMs, receivedOrder, businessResponse, null);
+    }
+
+    protected Server startOrderTrackingServer(int port, int setNameDelayMs, List<String> receivedOrder,
+                                              String businessResponse, CountDownLatch setNameReceived) throws Exception {
+        return startServer(port, new IoActionFactory() {
+            @Override
+            public IoAction createIoAction(Socket socket) {
+                return new AbstractIoAction(socket) {
+                    private String line;
+
+                    @Override
+                    protected Object doRead(InputStream ins) throws IOException {
+                        line = readLine(ins);
+                        return line;
+                    }
+
+                    @Override
+                    protected void doWrite(OutputStream ous, Object readResult) throws IOException {
+                        if (line == null) {
+                            return;
+                        }
+                        receivedOrder.add(line);
+                        if (line.toUpperCase().contains("CLIENT")) {
+                            if (setNameReceived != null) {
+                                setNameReceived.countDown();
+                            }
+                            if (setNameDelayMs > 0) {
+                                sleepIgnoreInterrupt(setNameDelayMs);
+                            }
+                            ous.write("+OK\r\n".getBytes());
+                        } else {
+                            ous.write(businessResponse.getBytes());
+                        }
+                        ous.flush();
+                    }
+                };
+            }
+        });
     }
 
 
-    protected Server startUnpackingServer(int port, String prefix) throws Exception {
+    protected Server startUnpackingServer(int port, String firstPart) throws Exception {
         return startServer(port, new IoActionFactory() {
 
-            boolean sended = false;
+            boolean setNameFirstPartSent = false;
 
             @Override
             public IoAction createIoAction(Socket socket) {
@@ -143,14 +348,21 @@ public class RedisAsyncNettyClientTest extends AsyncNettyClientTest {
 
                     @Override
                     protected void doWrite(OutputStream ous, Object readResult) throws IOException {
-                        if (prefix != null && !sended) {
-                            ous.write(prefix.getBytes());
-                            sended = true;
+                        if (line != null && line.toUpperCase().contains("CLIENT")) {
+                            if (!setNameFirstPartSent) {
+                                ous.write(firstPart.getBytes());
+                                ous.flush();
+                                setNameFirstPartSent = true;
+                                sleepIgnoreInterrupt(5);
+                                ous.write("K\r\n".getBytes());
+                                ous.flush();
+                            } else {
+                                ous.write("+OK\r\n".getBytes());
+                                ous.flush();
+                            }
+                            return;
                         }
-                        if (!line.contains("CLIENT")) {
-                            ous.write(line.getBytes());
-                        }
-                        sleepIgnoreInterrupt(1);
+                        ous.write("+PONG\r\n".getBytes());
                         ous.flush();
                     }
                 };
@@ -164,16 +376,35 @@ public class RedisAsyncNettyClientTest extends AsyncNettyClientTest {
                 new DefaultEndPoint("localhost", server.getPort()), "xpipe", () -> true);
         client.channel().attr(NettyClientHandler.KEY_CLIENT).set(client);
 
-        StringBuffer sb = new StringBuffer();
-
-        StringBuilder expected = new StringBuilder();
-
         int N = 100;
-        runTheTest(client, sb, expected, N, prefix);
-        waitConditionUntilTimeOut(()->client.channel().isActive(), 1000);
-        sleep(1000);
-        String str = sb.toString();
-        Assert.assertEquals(str, expected.toString());
+        AtomicInteger responseCount = new AtomicInteger(0);
+        for (int i = 0; i < N; i++) {
+            String message = "+" + i + "\r\n";
+            client.sendRequest(Unpooled.copiedBuffer(message.getBytes()), new ByteBufReceiver() {
+                private final RedisClientProtocol<String> parser = new SimpleStringParser();
+
+                @Override
+                public RECEIVER_RESULT receive(Channel channel, ByteBuf byteBuf) {
+                    if (parser.read(byteBuf) != null) {
+                        responseCount.incrementAndGet();
+                        return RECEIVER_RESULT.SUCCESS;
+                    }
+                    return RECEIVER_RESULT.CONTINUE;
+                }
+
+                @Override
+                public void clientClosed(NettyClient nettyClient) {
+                }
+
+                @Override
+                public void clientClosed(NettyClient nettyClient, Throwable th) {
+                }
+            });
+        }
+        waitConditionUntilTimeOut(client::getDoAfterConnectedSuccess, 2000);
+        waitConditionUntilTimeOut(() -> responseCount.get() == N, 5000);
+        Assert.assertEquals(N, responseCount.get());
+        Assert.assertTrue(client.getDoAfterConnectedSuccess());
     }
 
     @Test
@@ -206,6 +437,38 @@ public class RedisAsyncNettyClientTest extends AsyncNettyClientTest {
         sleep(2 * 1000);
     }
 
+    /**
+     * Respond +OK to CLIENT SETNAME; otherwise write the given business response once per request.
+     */
+    protected Server startRedisLikeServer(int port, String businessResponse) throws Exception {
+        return startServer(port, new IoActionFactory() {
+
+            @Override
+            public IoAction createIoAction(Socket socket) {
+                return new AbstractIoAction(socket) {
+
+                    private String line;
+
+                    @Override
+                    protected Object doRead(InputStream ins) throws IOException {
+                        line = readLine(ins);
+                        return line;
+                    }
+
+                    @Override
+                    protected void doWrite(OutputStream ous, Object readResult) throws IOException {
+                        if (line != null && line.toUpperCase().contains("CLIENT")) {
+                            ous.write("+OK\r\n".getBytes());
+                        } else {
+                            ous.write(businessResponse.getBytes());
+                        }
+                        ous.flush();
+                    }
+                };
+            }
+        });
+    }
+
 
     protected Server startEchoServer(int port, String prefix) throws Exception {
         return startServer(port, new IoActionFactory() {
@@ -226,6 +489,12 @@ public class RedisAsyncNettyClientTest extends AsyncNettyClientTest {
 
                     @Override
                     protected void doWrite(OutputStream ous, Object readResult) throws IOException {
+
+                        if (line != null && line.toUpperCase().contains("CLIENT")) {
+                            ous.write("+OK\r\n".getBytes());
+                            ous.flush();
+                            return;
+                        }
 
                         String[] sp = line.split("\\s+");
                         if (sp.length >= 1) {


### PR DESCRIPTION
修复RedisNettyClient潜在的问题
1. 在setname完成之前，channel就已经业务可用
2. 在setname发送之前，doAfterConnectedSuccess就已经标记成功